### PR TITLE
feat: T11 T12 T13 - APIs conductores, contratos y unidades disponibles

### DIFF
--- a/__tests__/unit/conductor-services/conductorController.test.mjs
+++ b/__tests__/unit/conductor-services/conductorController.test.mjs
@@ -1,0 +1,98 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let getAllConductoresController;
+let ConductorService, successResponse, errorResponse, SUCCESS_MESSAGES;
+
+const logSuccess = jest.fn();
+const logError = jest.fn();
+
+jest.unstable_mockModule("../../../src/functions/conductor-services/conductorService.mjs",
+  () => ({ ConductorService: jest.fn() }));
+
+jest.unstable_mockModule("../../../src/shared/utils/response/response.mjs",
+  () => ({ successResponse: jest.fn(), errorResponse: jest.fn() }));
+
+beforeAll(async () => {
+  ({ ConductorService } = await import("../../../src/functions/conductor-services/conductorService.mjs"));
+  ({ successResponse, errorResponse } = await import("../../../src/shared/utils/response/response.mjs"));
+  ({ SUCCESS_MESSAGES } = await import("../../../src/shared/constants/successMessages.mjs"));
+  ({ getAllConductoresController } = await import("../../../src/functions/conductor-services/conductorController.mjs"));
+});
+
+describe("conductorController", () => {
+  let mockService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockService = {
+      getAllActiveConductores: jest.fn(),
+    };
+
+    ConductorService.mockImplementation(() => mockService);
+
+    successResponse.mockImplementation((data, message) => {
+      logSuccess(data, message);
+      return { statusCode: 200, body: JSON.stringify({ success: true, data, message }) };
+    });
+
+    errorResponse.mockImplementation((message, statusCode) => {
+      logError(message, statusCode);
+      return { statusCode, body: JSON.stringify({ success: false, message }) };
+    });
+  });
+
+  describe("getAllConductoresController", () => {
+    it("debería retornar conductores exitosamente con status 200", async () => {
+      const mockConductores = [
+        {
+          id: 1,
+          nombre: "Carlos Mendoza",
+          dni: "12345678",
+          licencia: "A-001",
+          telefono: "999888777",
+          estado: "activo",
+        },
+        {
+          id: 2,
+          nombre: "Juan Pérez",
+          dni: "87654321",
+          licencia: "A-002",
+          telefono: "988777666",
+          estado: "activo",
+        },
+      ];
+
+      mockService.getAllActiveConductores.mockResolvedValue(mockConductores);
+
+      const event = {};
+      const result = await getAllConductoresController(event);
+
+      expect(result.statusCode).toBe(200);
+      expect(logSuccess).toHaveBeenCalledWith(mockConductores, SUCCESS_MESSAGES.CONDUCTORES_RETRIEVED);
+      expect(mockService.getAllActiveConductores).toHaveBeenCalled();
+    });
+
+    it("debería manejar error cuando el servicio falla con status 500", async () => {
+      const errorMessage = "Error en la base de datos";
+      mockService.getAllActiveConductores.mockRejectedValue(new Error(errorMessage));
+
+      const event = {};
+      const result = await getAllConductoresController(event);
+
+      expect(result.statusCode).toBe(500);
+      expect(logError).toHaveBeenCalledWith(errorMessage, 500);
+    });
+
+    it("debería retornar array vacío cuando no hay conductores con status 200", async () => {
+      mockService.getAllActiveConductores.mockResolvedValue([]);
+
+      const event = {};
+      const result = await getAllConductoresController(event);
+
+      expect(result.statusCode).toBe(200);
+      expect(logSuccess).toHaveBeenCalledWith([], SUCCESS_MESSAGES.CONDUCTORES_RETRIEVED);
+    });
+  });
+});

--- a/__tests__/unit/conductor-services/conductorService.test.mjs
+++ b/__tests__/unit/conductor-services/conductorService.test.mjs
@@ -1,0 +1,93 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let ConductorService, ConductorRepository, Conductor;
+
+jest.unstable_mockModule("../../../src/functions/conductor-services/conductorRepository.mjs",
+  () => ({ ConductorRepository: jest.fn() }));
+
+jest.unstable_mockModule("../../../src/functions/conductor-services/conductorModel.mjs",
+  () => ({ Conductor: { fromDatabaseList: jest.fn() } }));
+
+beforeAll(async () => {
+  ({ ConductorRepository } = await import("../../../src/functions/conductor-services/conductorRepository.mjs"));
+  ({ Conductor } = await import("../../../src/functions/conductor-services/conductorModel.mjs"));
+  ({ ConductorService } = await import("../../../src/functions/conductor-services/conductorService.mjs"));
+});
+
+describe("ConductorService", () => {
+  let mockRepository;
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRepository = {
+      getAllActive: jest.fn(),
+    };
+
+    ConductorRepository.mockImplementation(() => mockRepository);
+    service = new ConductorService();
+  });
+
+  describe("getAllActiveConductores", () => {
+    it("debería retornar lista de conductores activos", async () => {
+      const mockRows = [
+        {
+          id: 1,
+          nombre: "Carlos Mendoza",
+          dni: "12345678",
+          licencia: "A-001",
+          telefono: "999888777",
+          estado: "activo",
+        },
+        {
+          id: 2,
+          nombre: "Juan Pérez",
+          dni: "87654321",
+          licencia: "A-002",
+          telefono: "988777666",
+          estado: "activo",
+        },
+      ];
+
+      const mockConductores = [
+        {
+          id: 1,
+          nombre: "Carlos Mendoza",
+          dni: "12345678",
+          licencia: "A-001",
+          telefono: "999888777",
+          estado: "activo",
+        },
+        {
+          id: 2,
+          nombre: "Juan Pérez",
+          dni: "87654321",
+          licencia: "A-002",
+          telefono: "988777666",
+          estado: "activo",
+        },
+      ];
+
+      mockRepository.getAllActive.mockResolvedValue(mockRows);
+      Conductor.fromDatabaseList.mockReturnValue(mockConductores);
+
+      const result = await service.getAllActiveConductores();
+
+      expect(mockRepository.getAllActive).toHaveBeenCalled();
+      expect(Conductor.fromDatabaseList).toHaveBeenCalledWith(mockRows);
+      expect(result).toEqual(mockConductores);
+    });
+
+    it("debería retornar array vacío cuando no hay conductores", async () => {
+      mockRepository.getAllActive.mockResolvedValue([]);
+      Conductor.fromDatabaseList.mockReturnValue([]);
+
+      const result = await service.getAllActiveConductores();
+
+      expect(mockRepository.getAllActive).toHaveBeenCalled();
+      expect(Conductor.fromDatabaseList).toHaveBeenCalledWith([]);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/__tests__/unit/contrato-services/contratoController.test.mjs
+++ b/__tests__/unit/contrato-services/contratoController.test.mjs
@@ -1,0 +1,106 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let getAllVigentesController;
+let ContratoService, successResponse, errorResponse, SUCCESS_MESSAGES;
+
+const logSuccess = jest.fn();
+const logError = jest.fn();
+
+jest.unstable_mockModule("../../../src/functions/contrato-services/contratoService.mjs",
+  () => ({ ContratoService: jest.fn() }));
+
+jest.unstable_mockModule("../../../src/shared/utils/response/response.mjs",
+  () => ({ successResponse: jest.fn(), errorResponse: jest.fn() }));
+
+beforeAll(async () => {
+  ({ ContratoService } = await import("../../../src/functions/contrato-services/contratoService.mjs"));
+  ({ successResponse, errorResponse } = await import("../../../src/shared/utils/response/response.mjs"));
+  ({ SUCCESS_MESSAGES } = await import("../../../src/shared/constants/successMessages.mjs"));
+  ({ getAllVigentesController } = await import("../../../src/functions/contrato-services/contratoController.mjs"));
+});
+
+describe("contratoController", () => {
+  let mockService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockService = {
+      getAllVigentes: jest.fn(),
+    };
+
+    ContratoService.mockImplementation(() => mockService);
+
+    successResponse.mockImplementation((data, message) => {
+      logSuccess(data, message);
+      return { statusCode: 200, body: JSON.stringify({ success: true, data, message }) };
+    });
+
+    errorResponse.mockImplementation((message, statusCode) => {
+      logError(message, statusCode);
+      return { statusCode, body: JSON.stringify({ success: false, message }) };
+    });
+  });
+
+  describe("getAllVigentesController", () => {
+    it("debería retornar contratos vigentes exitosamente con status 200", async () => {
+      const mockContratos = [
+        {
+          id: 1,
+          codigo: "CTR-2026-001",
+          empresa: "Transportes XYZ",
+          tipo_servicio: "por_viaje",
+          tarifa: 500.0,
+          moneda: "PEN",
+          fecha_inicio: "2026-01-01",
+          fecha_fin: "2026-12-31",
+          estado: "activo",
+          descripcion: "Contrato anual",
+        },
+        {
+          id: 2,
+          codigo: "CTR-2026-002",
+          empresa: "Logística ABC",
+          tipo_servicio: "mensual",
+          tarifa: 1500.0,
+          moneda: "PEN",
+          fecha_inicio: "2026-02-01",
+          fecha_fin: "2026-11-30",
+          estado: "activo",
+          descripcion: "Contrato mensual",
+        },
+      ];
+
+      mockService.getAllVigentes.mockResolvedValue(mockContratos);
+
+      const event = {};
+      const result = await getAllVigentesController(event);
+
+      expect(result.statusCode).toBe(200);
+      expect(logSuccess).toHaveBeenCalledWith(mockContratos, SUCCESS_MESSAGES.CONTRATOS_RETRIEVED);
+      expect(mockService.getAllVigentes).toHaveBeenCalled();
+    });
+
+    it("debería manejar error cuando el servicio falla con status 500", async () => {
+      const errorMessage = "Error consultando contratos vigentes";
+      mockService.getAllVigentes.mockRejectedValue(new Error(errorMessage));
+
+      const event = {};
+      const result = await getAllVigentesController(event);
+
+      expect(result.statusCode).toBe(500);
+      expect(logError).toHaveBeenCalledWith(errorMessage, 500);
+    });
+
+    it("debería retornar array vacío cuando no hay contratos vigentes con status 200", async () => {
+      mockService.getAllVigentes.mockResolvedValue([]);
+
+      const event = {};
+      const result = await getAllVigentesController(event);
+
+      expect(result.statusCode).toBe(200);
+      expect(logSuccess).toHaveBeenCalledWith([], SUCCESS_MESSAGES.CONTRATOS_RETRIEVED);
+    });
+  });
+});

--- a/__tests__/unit/contrato-services/contratoService.test.mjs
+++ b/__tests__/unit/contrato-services/contratoService.test.mjs
@@ -1,0 +1,109 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let ContratoService, ContratoRepository, Contrato;
+
+jest.unstable_mockModule("../../../src/functions/contrato-services/contratoRepository.mjs",
+  () => ({ ContratoRepository: jest.fn() }));
+
+jest.unstable_mockModule("../../../src/functions/contrato-services/contratoModel.mjs",
+  () => ({ Contrato: { fromDatabaseList: jest.fn() } }));
+
+beforeAll(async () => {
+  ({ ContratoRepository } = await import("../../../src/functions/contrato-services/contratoRepository.mjs"));
+  ({ Contrato } = await import("../../../src/functions/contrato-services/contratoModel.mjs"));
+  ({ ContratoService } = await import("../../../src/functions/contrato-services/contratoService.mjs"));
+});
+
+describe("ContratoService", () => {
+  let mockRepository;
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRepository = {
+      getAllVigentes: jest.fn(),
+    };
+
+    ContratoRepository.mockImplementation(() => mockRepository);
+    service = new ContratoService();
+  });
+
+  describe("getAllVigentes", () => {
+    it("debería retornar lista de contratos vigentes", async () => {
+      const mockRows = [
+        {
+          id: 1,
+          codigo: "CTR-2026-001",
+          empresa: "Transportes XYZ",
+          tipo_servicio: "por_viaje",
+          tarifa: 500.0,
+          moneda: "PEN",
+          fecha_inicio: "2026-01-01",
+          fecha_fin: "2026-12-31",
+          estado: "activo",
+          descripcion: "Contrato anual",
+        },
+        {
+          id: 2,
+          codigo: "CTR-2026-002",
+          empresa: "Logística ABC",
+          tipo_servicio: "mensual",
+          tarifa: 1500.0,
+          moneda: "PEN",
+          fecha_inicio: "2026-02-01",
+          fecha_fin: "2026-11-30",
+          estado: "activo",
+          descripcion: "Contrato mensual",
+        },
+      ];
+
+      const mockContratos = [
+        {
+          id: 1,
+          codigo: "CTR-2026-001",
+          empresa: "Transportes XYZ",
+          tipo_servicio: "por_viaje",
+          tarifa: 500.0,
+          moneda: "PEN",
+          fecha_inicio: "2026-01-01",
+          fecha_fin: "2026-12-31",
+          estado: "activo",
+          descripcion: "Contrato anual",
+        },
+        {
+          id: 2,
+          codigo: "CTR-2026-002",
+          empresa: "Logística ABC",
+          tipo_servicio: "mensual",
+          tarifa: 1500.0,
+          moneda: "PEN",
+          fecha_inicio: "2026-02-01",
+          fecha_fin: "2026-11-30",
+          estado: "activo",
+          descripcion: "Contrato mensual",
+        },
+      ];
+
+      mockRepository.getAllVigentes.mockResolvedValue(mockRows);
+      Contrato.fromDatabaseList.mockReturnValue(mockContratos);
+
+      const result = await service.getAllVigentes();
+
+      expect(mockRepository.getAllVigentes).toHaveBeenCalled();
+      expect(Contrato.fromDatabaseList).toHaveBeenCalledWith(mockRows);
+      expect(result).toEqual(mockContratos);
+    });
+
+    it("debería retornar array vacío cuando no hay contratos vigentes", async () => {
+      mockRepository.getAllVigentes.mockResolvedValue([]);
+      Contrato.fromDatabaseList.mockReturnValue([]);
+
+      const result = await service.getAllVigentes();
+
+      expect(mockRepository.getAllVigentes).toHaveBeenCalled();
+      expect(Contrato.fromDatabaseList).toHaveBeenCalledWith([]);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/__tests__/unit/unidad-services/unidadController.test.mjs
+++ b/__tests__/unit/unidad-services/unidadController.test.mjs
@@ -1,0 +1,96 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let getAllDisponiblesController;
+let UnidadService, successResponse, errorResponse, SUCCESS_MESSAGES;
+
+const logSuccess = jest.fn();
+const logError = jest.fn();
+
+jest.unstable_mockModule("../../../src/functions/unidad-services/unidadService.mjs",
+  () => ({ UnidadService: jest.fn() }));
+
+jest.unstable_mockModule("../../../src/shared/utils/response/response.mjs",
+  () => ({ successResponse: jest.fn(), errorResponse: jest.fn() }));
+
+beforeAll(async () => {
+  ({ UnidadService } = await import("../../../src/functions/unidad-services/unidadService.mjs"));
+  ({ successResponse, errorResponse } = await import("../../../src/shared/utils/response/response.mjs"));
+  ({ SUCCESS_MESSAGES } = await import("../../../src/shared/constants/successMessages.mjs"));
+  ({ getAllDisponiblesController } = await import("../../../src/functions/unidad-services/unidadController.mjs"));
+});
+
+describe("unidadController", () => {
+  let mockService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockService = {
+      getAllDisponibles: jest.fn(),
+    };
+
+    UnidadService.mockImplementation(() => mockService);
+
+    successResponse.mockImplementation((data, message) => {
+      logSuccess(data, message);
+      return { statusCode: 200, body: JSON.stringify({ success: true, data, message }) };
+    });
+
+    errorResponse.mockImplementation((message, statusCode) => {
+      logError(message, statusCode);
+      return { statusCode, body: JSON.stringify({ success: false, message }) };
+    });
+  });
+
+  describe("getAllDisponiblesController", () => {
+    it("debería retornar unidades disponibles exitosamente con status 200", async () => {
+      const mockUnidades = [
+        {
+          id: 1,
+          placa: "ABC-123",
+          marca: "Mercedes",
+          modelo: "Actros 2021",
+          estado: "activo",
+        },
+        {
+          id: 2,
+          placa: "XYZ-456",
+          marca: "Volvo",
+          modelo: "FH16 2020",
+          estado: "activo",
+        },
+      ];
+
+      mockService.getAllDisponibles.mockResolvedValue(mockUnidades);
+
+      const event = {};
+      const result = await getAllDisponiblesController(event);
+
+      expect(result.statusCode).toBe(200);
+      expect(logSuccess).toHaveBeenCalledWith(mockUnidades, SUCCESS_MESSAGES.UNIDADES_RETRIEVED);
+      expect(mockService.getAllDisponibles).toHaveBeenCalled();
+    });
+
+    it("debería manejar error cuando el servicio falla con status 500", async () => {
+      const errorMessage = "Error consultando unidades disponibles";
+      mockService.getAllDisponibles.mockRejectedValue(new Error(errorMessage));
+
+      const event = {};
+      const result = await getAllDisponiblesController(event);
+
+      expect(result.statusCode).toBe(500);
+      expect(logError).toHaveBeenCalledWith(errorMessage, 500);
+    });
+
+    it("debería retornar array vacío cuando no hay unidades disponibles con status 200", async () => {
+      mockService.getAllDisponibles.mockResolvedValue([]);
+
+      const event = {};
+      const result = await getAllDisponiblesController(event);
+
+      expect(result.statusCode).toBe(200);
+      expect(logSuccess).toHaveBeenCalledWith([], SUCCESS_MESSAGES.UNIDADES_RETRIEVED);
+    });
+  });
+});

--- a/__tests__/unit/unidad-services/unidadService.test.mjs
+++ b/__tests__/unit/unidad-services/unidadService.test.mjs
@@ -1,0 +1,89 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let UnidadService, UnidadRepository, Unidad;
+
+jest.unstable_mockModule("../../../src/functions/unidad-services/unidadRepository.mjs",
+  () => ({ UnidadRepository: jest.fn() }));
+
+jest.unstable_mockModule("../../../src/functions/unidad-services/unidadModel.mjs",
+  () => ({ Unidad: { fromDatabaseList: jest.fn() } }));
+
+beforeAll(async () => {
+  ({ UnidadRepository } = await import("../../../src/functions/unidad-services/unidadRepository.mjs"));
+  ({ Unidad } = await import("../../../src/functions/unidad-services/unidadModel.mjs"));
+  ({ UnidadService } = await import("../../../src/functions/unidad-services/unidadService.mjs"));
+});
+
+describe("UnidadService", () => {
+  let mockRepository;
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRepository = {
+      getAllDisponibles: jest.fn(),
+    };
+
+    UnidadRepository.mockImplementation(() => mockRepository);
+    service = new UnidadService();
+  });
+
+  describe("getAllDisponibles", () => {
+    it("debería retornar lista de unidades disponibles", async () => {
+      const mockRows = [
+        {
+          id: 1,
+          placa: "ABC-123",
+          marca: "Mercedes",
+          modelo: "Actros 2021",
+          estado: "activo",
+        },
+        {
+          id: 2,
+          placa: "XYZ-456",
+          marca: "Volvo",
+          modelo: "FH16 2020",
+          estado: "activo",
+        },
+      ];
+
+      const mockUnidades = [
+        {
+          id: 1,
+          placa: "ABC-123",
+          marca: "Mercedes",
+          modelo: "Actros 2021",
+          estado: "activo",
+        },
+        {
+          id: 2,
+          placa: "XYZ-456",
+          marca: "Volvo",
+          modelo: "FH16 2020",
+          estado: "activo",
+        },
+      ];
+
+      mockRepository.getAllDisponibles.mockResolvedValue(mockRows);
+      Unidad.fromDatabaseList.mockReturnValue(mockUnidades);
+
+      const result = await service.getAllDisponibles();
+
+      expect(mockRepository.getAllDisponibles).toHaveBeenCalled();
+      expect(Unidad.fromDatabaseList).toHaveBeenCalledWith(mockRows);
+      expect(result).toEqual(mockUnidades);
+    });
+
+    it("debería retornar array vacío cuando no hay unidades disponibles", async () => {
+      mockRepository.getAllDisponibles.mockResolvedValue([]);
+      Unidad.fromDatabaseList.mockReturnValue([]);
+
+      const result = await service.getAllDisponibles();
+
+      expect(mockRepository.getAllDisponibles).toHaveBeenCalled();
+      expect(Unidad.fromDatabaseList).toHaveBeenCalledWith([]);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/conductor-services/conductorController.mjs
+++ b/src/functions/conductor-services/conductorController.mjs
@@ -1,0 +1,14 @@
+import { ConductorService } from "./conductorService.mjs";
+import { successResponse, errorResponse } from "../../shared/utils/response/response.mjs";
+import { SUCCESS_MESSAGES } from "../../shared/constants/successMessages.mjs";
+
+export const getAllConductoresController = async (event) => {
+  try {
+    const conductorService = new ConductorService();
+    const conductores = await conductorService.getAllActiveConductores();
+    return successResponse(conductores, SUCCESS_MESSAGES.CONDUCTORES_RETRIEVED);
+  } catch (error) {
+    console.error("Error en getAllConductoresController:", error);
+    return errorResponse(error.message, 500);
+  }
+};

--- a/src/functions/conductor-services/conductorHandler.mjs
+++ b/src/functions/conductor-services/conductorHandler.mjs
@@ -1,0 +1,27 @@
+import { getAllConductoresController } from "./conductorController.mjs";
+
+const routes = {
+  "GET /conductores": getAllConductoresController,
+};
+
+export const handler = async (event) => {
+  try {
+    const routeKey = `${event.httpMethod} ${event.resource}`;
+    const controller = routes[routeKey];
+    if (!controller) {
+      return {
+        statusCode: 404,
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+        body: JSON.stringify({ success: false, message: `Ruta ${routeKey} no encontrada` }),
+      };
+    }
+    return await controller(event);
+  } catch (error) {
+    console.error("Error en handler:", error);
+    return {
+      statusCode: 500,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      body: JSON.stringify({ success: false, error: "Error interno del servidor", message: error.message }),
+    };
+  }
+};

--- a/src/functions/conductor-services/conductorModel.mjs
+++ b/src/functions/conductor-services/conductorModel.mjs
@@ -1,0 +1,25 @@
+export class Conductor {
+  constructor(id, nombre, dni, licencia, telefono, estado) {
+    this.id = id;
+    this.nombre = nombre;
+    this.dni = dni;
+    this.licencia = licencia;
+    this.telefono = telefono;
+    this.estado = estado;
+  }
+
+  static fromDatabase(row) {
+    return new Conductor(
+      row.id,
+      row.nombre,
+      row.dni,
+      row.licencia,
+      row.telefono,
+      row.estado
+    );
+  }
+
+  static fromDatabaseList(rows) {
+    return rows.map((row) => Conductor.fromDatabase(row));
+  }
+}

--- a/src/functions/conductor-services/conductorRepository.mjs
+++ b/src/functions/conductor-services/conductorRepository.mjs
@@ -1,0 +1,13 @@
+import db from "../../shared/config/database.mjs";
+
+export class ConductorRepository {
+  async getAllActive() {
+    const result = await db.query(
+      `SELECT id, nombre, dni, licencia, telefono, estado 
+       FROM conductores 
+       WHERE estado = 'activo' 
+       ORDER BY nombre`
+    );
+    return result.rows;
+  }
+}

--- a/src/functions/conductor-services/conductorService.mjs
+++ b/src/functions/conductor-services/conductorService.mjs
@@ -1,0 +1,10 @@
+import { ConductorRepository } from "./conductorRepository.mjs";
+import { Conductor } from "./conductorModel.mjs";
+
+export class ConductorService {
+  async getAllActiveConductores() {
+    const conductorRepository = new ConductorRepository();
+    const rows = await conductorRepository.getAllActive();
+    return Conductor.fromDatabaseList(rows);
+  }
+}

--- a/src/functions/contrato-services/contratoController.mjs
+++ b/src/functions/contrato-services/contratoController.mjs
@@ -1,0 +1,14 @@
+import { ContratoService } from "./contratoService.mjs";
+import { successResponse, errorResponse } from "../../shared/utils/response/response.mjs";
+import { SUCCESS_MESSAGES } from "../../shared/constants/successMessages.mjs";
+
+export const getAllVigentesController = async (event) => {
+  try {
+    const contratoService = new ContratoService();
+    const contratos = await contratoService.getAllVigentes();
+    return successResponse(contratos, SUCCESS_MESSAGES.CONTRATOS_RETRIEVED);
+  } catch (error) {
+    console.error("Error en getAllVigentesController:", error);
+    return errorResponse(error.message, 500);
+  }
+};

--- a/src/functions/contrato-services/contratoHandler.mjs
+++ b/src/functions/contrato-services/contratoHandler.mjs
@@ -1,0 +1,27 @@
+import { getAllVigentesController } from "./contratoController.mjs";
+
+const routes = {
+  "GET /contratos/vigentes": getAllVigentesController,
+};
+
+export const handler = async (event) => {
+  try {
+    const routeKey = `${event.httpMethod} ${event.resource}`;
+    const controller = routes[routeKey];
+    if (!controller) {
+      return {
+        statusCode: 404,
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+        body: JSON.stringify({ success: false, message: `Ruta ${routeKey} no encontrada` }),
+      };
+    }
+    return await controller(event);
+  } catch (error) {
+    console.error("Error en handler:", error);
+    return {
+      statusCode: 500,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      body: JSON.stringify({ success: false, error: "Error interno del servidor", message: error.message }),
+    };
+  }
+};

--- a/src/functions/contrato-services/contratoModel.mjs
+++ b/src/functions/contrato-services/contratoModel.mjs
@@ -1,0 +1,33 @@
+export class Contrato {
+  constructor(id, codigo, empresa, tipo_servicio, tarifa, moneda, fecha_inicio, fecha_fin, estado, descripcion) {
+    this.id = id;
+    this.codigo = codigo;
+    this.empresa = empresa;
+    this.tipo_servicio = tipo_servicio;
+    this.tarifa = tarifa;
+    this.moneda = moneda;
+    this.fecha_inicio = fecha_inicio;
+    this.fecha_fin = fecha_fin;
+    this.estado = estado;
+    this.descripcion = descripcion;
+  }
+
+  static fromDatabase(row) {
+    return new Contrato(
+      row.id,
+      row.codigo,
+      row.empresa,
+      row.tipo_servicio,
+      row.tarifa,
+      row.moneda,
+      row.fecha_inicio,
+      row.fecha_fin,
+      row.estado,
+      row.descripcion
+    );
+  }
+
+  static fromDatabaseList(rows) {
+    return rows.map((row) => Contrato.fromDatabase(row));
+  }
+}

--- a/src/functions/contrato-services/contratoRepository.mjs
+++ b/src/functions/contrato-services/contratoRepository.mjs
@@ -1,0 +1,16 @@
+import db from "../../shared/config/database.mjs";
+
+export class ContratoRepository {
+  async getAllVigentes() {
+    const result = await db.query(
+      `SELECT id, codigo, empresa, tipo_servicio, tarifa, moneda,
+              fecha_inicio, fecha_fin, estado, descripcion
+       FROM contratos
+       WHERE estado = 'activo'
+         AND fecha_inicio <= CURRENT_DATE
+         AND fecha_fin >= CURRENT_DATE
+       ORDER BY empresa`
+    );
+    return result.rows;
+  }
+}

--- a/src/functions/contrato-services/contratoService.mjs
+++ b/src/functions/contrato-services/contratoService.mjs
@@ -1,0 +1,10 @@
+import { ContratoRepository } from "./contratoRepository.mjs";
+import { Contrato } from "./contratoModel.mjs";
+
+export class ContratoService {
+  async getAllVigentes() {
+    const contratoRepository = new ContratoRepository();
+    const rows = await contratoRepository.getAllVigentes();
+    return Contrato.fromDatabaseList(rows);
+  }
+}

--- a/src/functions/unidad-services/unidadController.mjs
+++ b/src/functions/unidad-services/unidadController.mjs
@@ -1,0 +1,14 @@
+import { UnidadService } from "./unidadService.mjs";
+import { successResponse, errorResponse } from "../../shared/utils/response/response.mjs";
+import { SUCCESS_MESSAGES } from "../../shared/constants/successMessages.mjs";
+
+export const getAllDisponiblesController = async (event) => {
+  try {
+    const unidadService = new UnidadService();
+    const unidades = await unidadService.getAllDisponibles();
+    return successResponse(unidades, SUCCESS_MESSAGES.UNIDADES_RETRIEVED);
+  } catch (error) {
+    console.error("Error en getAllDisponiblesController:", error);
+    return errorResponse(error.message, 500);
+  }
+};

--- a/src/functions/unidad-services/unidadHandler.mjs
+++ b/src/functions/unidad-services/unidadHandler.mjs
@@ -1,0 +1,27 @@
+import { getAllDisponiblesController } from "./unidadController.mjs";
+
+const routes = {
+  "GET /unidades/disponibles": getAllDisponiblesController,
+};
+
+export const handler = async (event) => {
+  try {
+    const routeKey = `${event.httpMethod} ${event.resource}`;
+    const controller = routes[routeKey];
+    if (!controller) {
+      return {
+        statusCode: 404,
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+        body: JSON.stringify({ success: false, message: `Ruta ${routeKey} no encontrada` }),
+      };
+    }
+    return await controller(event);
+  } catch (error) {
+    console.error("Error en handler:", error);
+    return {
+      statusCode: 500,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      body: JSON.stringify({ success: false, error: "Error interno del servidor", message: error.message }),
+    };
+  }
+};

--- a/src/functions/unidad-services/unidadModel.mjs
+++ b/src/functions/unidad-services/unidadModel.mjs
@@ -1,0 +1,23 @@
+export class Unidad {
+  constructor(id, placa, marca, modelo, estado) {
+    this.id = id;
+    this.placa = placa;
+    this.marca = marca;
+    this.modelo = modelo;
+    this.estado = estado;
+  }
+
+  static fromDatabase(row) {
+    return new Unidad(
+      row.id,
+      row.placa,
+      row.marca,
+      row.modelo,
+      row.estado
+    );
+  }
+
+  static fromDatabaseList(rows) {
+    return rows.map((row) => Unidad.fromDatabase(row));
+  }
+}

--- a/src/functions/unidad-services/unidadRepository.mjs
+++ b/src/functions/unidad-services/unidadRepository.mjs
@@ -1,0 +1,16 @@
+import db from "../../shared/config/database.mjs";
+
+export class UnidadRepository {
+  async getAllDisponibles() {
+    const result = await db.query(
+      `SELECT id, placa, marca, modelo, estado
+       FROM camiones
+       WHERE estado = 'activo'
+         AND id NOT IN (
+           SELECT camion_id FROM jornadas WHERE estado = 'iniciada'
+         )
+       ORDER BY placa`
+    );
+    return result.rows;
+  }
+}

--- a/src/functions/unidad-services/unidadService.mjs
+++ b/src/functions/unidad-services/unidadService.mjs
@@ -1,0 +1,10 @@
+import { UnidadRepository } from "./unidadRepository.mjs";
+import { Unidad } from "./unidadModel.mjs";
+
+export class UnidadService {
+  async getAllDisponibles() {
+    const unidadRepository = new UnidadRepository();
+    const rows = await unidadRepository.getAllDisponibles();
+    return Unidad.fromDatabaseList(rows);
+  }
+}

--- a/src/shared/constants/successMessages.mjs
+++ b/src/shared/constants/successMessages.mjs
@@ -6,10 +6,17 @@ export const SUCCESS_MESSAGES = {
   CAMION_RETRIEVED: "Camión obtenido exitosamente",
   CAMIONES_RETRIEVED: "Camiones obtenidos exitosamente",
 
+  // Conductor messages
+  CONDUCTOR_RETRIEVED: "Conductor obtenido exitosamente",
+  CONDUCTORES_RETRIEVED: "Conductores obtenidos exitosamente",
+
   // Contrato messages
   CONTRATO_CREATED: "Contrato creado exitosamente",
   CONTRATO_UPDATED: "Contrato actualizado exitosamente",
   CONTRATO_DELETED: "Contrato eliminado exitosamente",
   CONTRATO_RETRIEVED: "Contrato obtenido exitosamente",
   CONTRATOS_RETRIEVED: "Contratos obtenidos exitosamente",
+
+  // Unidad messages
+  UNIDADES_RETRIEVED: "Unidades disponibles obtenidas exitosamente",
 };


### PR DESCRIPTION
HU02 - Registro de Nueva Jornada (T11, T12, T13)

APIs implementadas
- GET /conductores → lista conductores con estado activo
- GET /contratos/vigentes → lista contratos vigentes por fecha actual
- GET /unidades/disponibles → lista camiones sin jornada activa

Archivos agregados
- src/functions/conductor-services/ (5 archivos)
- src/functions/contrato-services/ (5 archivos)
- src/functions/unidad-services/ (5 archivos)
- src/shared/constants/successMessages.mjs (actualizado)

Notas
- Sigue el patrón Handler → Controller → Service → Repository → Model
- Formato de respuesta estándar { success, data, message }
- No se modificó package.json ni template.yaml