### PR TITLE
feat(jornada): implementar registro de nueva jornada y validacion de …

### DIFF
--- a/__tests__/unit/jornada-services-test/jornadaController.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaController.test.mjs
@@ -1,0 +1,64 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule(
+  "../../../src/functions/jornada-services/jornadaService.mjs",
+  () => {
+    return {
+      JornadaService: jest.fn().mockImplementation(() => ({
+        createJornada: jest.fn(),
+      })),
+    };
+  },
+);
+
+const { JornadaService } =
+  await import("../../../src/functions/jornada-services/jornadaService.mjs");
+const { createJornadaController } =
+  await import("../../../src/functions/jornada-services/jornadaController.mjs");
+
+describe("jornadaController", () => {
+  let mockServiceInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Debe retornar successResponse cuando el servicio registra jornada correctamente", async () => {
+    const event = {
+      body: JSON.stringify({ id_conductor: 1, id_unidad: 2, id_contrato: 3 }),
+    };
+    const mockJornada = {
+      id: 10,
+      id_conductor: 1,
+      id_unidad: 2,
+      id_contrato: 3,
+      estado: "ACTIVA",
+    };
+
+    JornadaService.mockImplementation(() => ({
+      createJornada: jest.fn().mockResolvedValue(mockJornada),
+    }));
+
+    const response = await createJornadaController(event);
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual(mockJornada);
+  });
+
+  test("Debe retornar errorResponse 400 cuando el servicio lanza error de validación", async () => {
+    const event = { body: JSON.stringify({}) };
+
+    JornadaService.mockImplementation(() => ({
+      createJornada: jest
+        .fn()
+        .mockRejectedValue(new Error("El id_conductor es requerido")),
+    }));
+
+    const response = await createJornadaController(event);
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.success).toBe(false);
+    expect(body.message).toContain("requerido");
+  });
+});

--- a/__tests__/unit/jornada-services-test/jornadaHandler.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaHandler.test.mjs
@@ -1,0 +1,35 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule(
+  "../../../src/functions/jornada-services/jornadaController.mjs",
+  () => ({
+    createJornadaController: jest.fn(),
+  }),
+);
+
+const { handler } =
+  await import("../../../src/functions/jornada-services/jornadaHandler.mjs");
+const { createJornadaController } =
+  await import("../../../src/functions/jornada-services/jornadaController.mjs");
+
+describe("jornadaHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Debe llamar a createJornadaController cuando el método es POST", async () => {
+    const event = { requestContext: { http: { method: "POST" } } };
+    const expectedResponse = { statusCode: 200, body: '{"success":true}' };
+    createJornadaController.mockResolvedValue(expectedResponse);
+
+    const response = await handler(event);
+    expect(createJornadaController).toHaveBeenCalledWith(event);
+    expect(response).toEqual(expectedResponse);
+  });
+
+  test("Debe retornar 404 para métodos no soportados", async () => {
+    const event = { requestContext: { http: { method: "GET" } } };
+    const response = await handler(event);
+    expect(response.statusCode).toBe(404);
+  });
+});

--- a/__tests__/unit/jornada-services-test/jornadaRepository.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaRepository.test.mjs
@@ -1,0 +1,50 @@
+import { jest } from "@jest/globals";
+
+const mockQuery = jest.fn();
+const mockRelease = jest.fn();
+
+jest.unstable_mockModule("../../../src/shared/config/database.mjs", () => ({
+  getDbClient: jest.fn().mockResolvedValue({
+    query: mockQuery,
+    release: mockRelease,
+  }),
+}));
+
+const { JornadaRepository } =
+  await import("../../../src/functions/jornada-services/jornadaRepository.mjs");
+
+describe("jornadaRepository", () => {
+  let repository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new JornadaRepository();
+  });
+
+  test("Debe insertar y retornar la jornada en create()", async () => {
+    const jornadaData = {
+      id_conductor: 1,
+      id_unidad: 2,
+      id_contrato: 3,
+      estado: "ACTIVA",
+    };
+    const mockDbRow = { id: 1, ...jornadaData };
+
+    mockQuery.mockResolvedValue({ rows: [mockDbRow] });
+
+    const result = await repository.create(jornadaData);
+
+    expect(mockQuery).toHaveBeenCalled();
+    expect(mockRelease).toHaveBeenCalled();
+    expect(result).toEqual(mockDbRow);
+  });
+
+  test("Debe verificar si la unidad está activa en checkUnidadActiva()", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: 1 }] });
+
+    const result = await repository.checkUnidadActiva(2);
+
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), [2]);
+    expect(result).toBe(true);
+  });
+});

--- a/__tests__/unit/jornada-services-test/jornadaService.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaService.test.mjs
@@ -1,0 +1,63 @@
+import { jest } from "@jest/globals";
+
+// Mock dependencias
+jest.unstable_mockModule(
+  "../../../src/functions/jornada-services/jornadaRepository.mjs",
+  () => {
+    return {
+      JornadaRepository: jest.fn().mockImplementation(() => ({
+        checkUnidadActiva: jest.fn(),
+        create: jest.fn(),
+      })),
+    };
+  },
+);
+
+// Cargar modulo DESPUES del mock para ES modules en Jest
+const { JornadaService } =
+  await import("../../../src/functions/jornada-services/jornadaService.mjs");
+
+describe("JornadaService - Pruebas de Integración T18", () => {
+  let jornadaService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jornadaService = new JornadaService();
+  });
+
+  test("T18: Debe lanzar error si se intenta registrar una jornada con unidad ya asignada (activa)", async () => {
+    jornadaService.repository.checkUnidadActiva.mockResolvedValue(true);
+
+    const data = {
+      id_conductor: 1,
+      id_unidad: 101,
+      id_contrato: 50,
+    };
+
+    await expect(jornadaService.createJornada(data)).rejects.toThrow(
+      "La unidad ya tiene una jornada activa.",
+    );
+    expect(jornadaService.repository.create).not.toHaveBeenCalled();
+  });
+
+  test("Debe registrar jornada si la unidad está disponible", async () => {
+    jornadaService.repository.checkUnidadActiva.mockResolvedValue(false);
+
+    const dbResponse = {
+      id: 99,
+      id_conductor: 1,
+      id_unidad: 102,
+      id_contrato: 50,
+      estado: "ACTIVA",
+    };
+    jornadaService.repository.create.mockResolvedValue(dbResponse);
+
+    const data = { id_conductor: 1, id_unidad: 102, id_contrato: 50 };
+    const result = await jornadaService.createJornada(data);
+
+    expect(result.id).toBe(99);
+    expect(jornadaService.repository.create).toHaveBeenCalledWith(
+      expect.objectContaining(data),
+    );
+  });
+});

--- a/src/functions/jornada-services/jornadaController.mjs
+++ b/src/functions/jornada-services/jornadaController.mjs
@@ -1,0 +1,26 @@
+import { JornadaService } from "./jornadaService.mjs";
+import {
+  successResponse,
+  errorResponse,
+} from "../../shared/utils/response/response.mjs";
+
+export const createJornadaController = async (event) => {
+  try {
+    const body = event.body ? JSON.parse(event.body) : {};
+    const jornadaService = new JornadaService();
+
+    const jornada = await jornadaService.createJornada(body);
+
+    return successResponse(jornada, "Jornada registrada exitosamente.");
+  } catch (error) {
+    console.error("Error en createJornadaController:", error);
+    if (
+      error.message.includes("requerido") ||
+      error.message.includes("activa") ||
+      error.message.includes("inválidos")
+    ) {
+      return errorResponse(error.message, 400);
+    }
+    return errorResponse("Error en el servidor al registrar la jornada", 500);
+  }
+};

--- a/src/functions/jornada-services/jornadaHandler.mjs
+++ b/src/functions/jornada-services/jornadaHandler.mjs
@@ -1,0 +1,16 @@
+import { createJornadaController } from "./jornadaController.mjs";
+
+export const handler = async (event) => {
+  const method = event.requestContext?.http?.method || event.httpMethod;
+
+  if (method === "POST") {
+    return await createJornadaController(event);
+  }
+
+  return {
+    statusCode: 404,
+    body: JSON.stringify({
+      message: "Ruta o método no encontrado para jornadas",
+    }),
+  };
+};

--- a/src/functions/jornada-services/jornadaModel.mjs
+++ b/src/functions/jornada-services/jornadaModel.mjs
@@ -1,0 +1,40 @@
+export class Jornada {
+  constructor(
+    id,
+    id_conductor,
+    id_unidad,
+    id_contrato,
+    estado,
+    fecha_registro,
+  ) {
+    this.id = id;
+    this.id_conductor = id_conductor;
+    this.id_unidad = id_unidad;
+    this.id_contrato = id_contrato;
+    this.estado = estado;
+    this.fecha_registro = fecha_registro;
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      id_conductor: this.id_conductor,
+      id_unidad: this.id_unidad,
+      id_contrato: this.id_contrato,
+      estado: this.estado,
+      fecha_registro: this.fecha_registro,
+    };
+  }
+
+  static fromDatabase(row) {
+    if (!row) return null;
+    return new Jornada(
+      row.id,
+      row.id_conductor,
+      row.id_unidad,
+      row.id_contrato,
+      row.estado,
+      row.fecha_registro,
+    );
+  }
+}

--- a/src/functions/jornada-services/jornadaRepository.mjs
+++ b/src/functions/jornada-services/jornadaRepository.mjs
@@ -1,0 +1,35 @@
+import { getDbClient } from "../../shared/config/database.mjs";
+
+export class JornadaRepository {
+  async create(jornadaData) {
+    const client = await getDbClient();
+    try {
+      const query = `
+        INSERT INTO jornadas (id_conductor, id_unidad, id_contrato, estado)
+        VALUES ($1, $2, $3, $4)
+        RETURNING *;
+      `;
+      const values = [
+        jornadaData.id_conductor,
+        jornadaData.id_unidad,
+        jornadaData.id_contrato,
+        jornadaData.estado,
+      ];
+      const result = await client.query(query, values);
+      return result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  async checkUnidadActiva(id_unidad) {
+    const client = await getDbClient();
+    try {
+      const query = `SELECT id FROM jornadas WHERE id_unidad = $1 AND estado = 'ACTIVA' LIMIT 1;`;
+      const result = await client.query(query, [id_unidad]);
+      return result.rows.length > 0;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/functions/jornada-services/jornadaService.mjs
+++ b/src/functions/jornada-services/jornadaService.mjs
@@ -1,0 +1,28 @@
+import { JornadaRepository } from "./jornadaRepository.mjs";
+import { Jornada } from "./jornadaModel.mjs";
+import { JornadaValidator } from "../../shared/utils/validators/jornadaValidator.mjs";
+
+export class JornadaService {
+  constructor() {
+    this.repository = new JornadaRepository();
+  }
+
+  async createJornada(jornadaData) {
+    try {
+      const validatedData = JornadaValidator.validateCreateJornada(jornadaData);
+
+      const unidadOcupada = await this.repository.checkUnidadActiva(
+        validatedData.id_unidad,
+      );
+      if (unidadOcupada) {
+        throw new Error("La unidad ya tiene una jornada activa.");
+      }
+
+      const createdDb = await this.repository.create(validatedData);
+      return Jornada.fromDatabase(createdDb);
+    } catch (error) {
+      console.error("Error en createJornada service:", error);
+      throw error;
+    }
+  }
+}

--- a/src/shared/utils/validators/jornadaValidator.mjs
+++ b/src/shared/utils/validators/jornadaValidator.mjs
@@ -1,0 +1,17 @@
+export class JornadaValidator {
+  static validateCreateJornada(data) {
+    if (!data || typeof data !== "object") {
+      throw new Error("Datos de jornada inválidos");
+    }
+    if (!data.id_conductor) throw new Error("El id_conductor es requerido");
+    if (!data.id_unidad) throw new Error("El id_unidad (camión) es requerido");
+    if (!data.id_contrato) throw new Error("El id_contrato es requerido");
+
+    return {
+      id_conductor: data.id_conductor,
+      id_unidad: data.id_unidad,
+      id_contrato: data.id_contrato,
+      estado: data.estado || "ACTIVA",
+    };
+  }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -113,6 +113,36 @@ Resources:
         EntryPoints:
           - src/functions/camion-services/camionHandler.mjs
 
+  JornadaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${StageName}-jornadas"
+      CodeUri: .
+      Handler: src/functions/jornada-services/jornadaHandler.handler
+      Policies:
+        - AWSLambdaBasicExecutionRole
+      Environment:
+        Variables:
+          LOG_LEVEL: "debug"
+      Events:
+        Create:
+          Type: Api
+          Properties:
+            RestApiId: !Ref NanutechApi
+            Path: /jornadas
+            Method: POST
+      Tags:
+        Environment: !Ref StageName
+        Servicio: jornada
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: false
+        Target: es2022
+        Sourcemap: true
+        EntryPoints:
+          - src/functions/jornada-services/jornadaHandler.mjs
+
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group
     Properties:
@@ -133,3 +163,6 @@ Outputs:
   CamionFunctionArn:
     Description: "ARN de la función Camion"
     Value: !GetAtt CamionFunction.Arn
+  JornadaFunctionArn:
+    Description: "ARN de la función Jornada"
+    Value: !GetAtt JornadaFunction.Arn


### PR DESCRIPTION
…disponibilidad

T15: Se agregó la estructura base requerida de jornada-services (Handler, Controller, Service, Repository, Model). T15: Se implementó la persistencia en PostgreSQL y el formato unificado de respuestas, junto con su propio validador (jornadaValidator). T18: Se añadió la regla de negocio en el Service para bloquear el registro si el camión ya tiene una jornada activa. Se incluyeron pruebas unitarias y de integración para todas las capas exigidas por el README, logrando 100% PASS localmente.