### PR TITLE
feat: agregar GET /jornadas - listado completo de jornadas HU02

### DIFF
--- a/__tests__/unit/jornada-services-test/jornadaHandler.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaHandler.test.mjs
@@ -4,6 +4,7 @@ jest.unstable_mockModule(
   "../../../src/functions/jornada-services/jornadaController.mjs",
   () => ({
     createJornadaController: jest.fn(),
+    getAllJornadasController: jest.fn(), 
     getCurrentJornadaController: jest.fn(),
     startTurnController: jest.fn(),
     finishTurnController: jest.fn(),

--- a/src/functions/jornada-services/jornadaController.mjs
+++ b/src/functions/jornada-services/jornadaController.mjs
@@ -76,3 +76,13 @@ export const finishTurnController = async (event) => {
     return resolveErrorResponse(error);
   }
 };
+export const getAllJornadasController = async (_event) => {
+  try {
+    const jornadaService = new JornadaService();
+    const data = await jornadaService.getAllJornadas();
+    return successResponse(data, "Jornadas obtenidas exitosamente.");
+  } catch (error) {
+    console.error("Error en getAllJornadasController:", error);
+    return resolveErrorResponse(error);
+  }
+};

--- a/src/functions/jornada-services/jornadaHandler.mjs
+++ b/src/functions/jornada-services/jornadaHandler.mjs
@@ -1,5 +1,6 @@
 import {
   createJornadaController,
+  getAllJornadasController,
   getCurrentJornadaController,
   startTurnController,
   finishTurnController,
@@ -9,6 +10,7 @@ import { errorResponse } from "../../shared/utils/response/response.mjs";
 const ROUTES = {
   "POST /jornadas": createJornadaController,
   "GET /jornadas/actual/{conductorId}": getCurrentJornadaController,
+  "GET /jornadas": getAllJornadasController,
   "POST /jornadas/iniciar": startTurnController,
   "POST /jornadas/finalizar": finishTurnController,
 };
@@ -27,3 +29,4 @@ export const handler = async (event) => {
 
   return routeHandler(event);
 };
+

--- a/src/functions/jornada-services/jornadaRepository.mjs
+++ b/src/functions/jornada-services/jornadaRepository.mjs
@@ -214,4 +214,35 @@ export class JornadaRepository {
       client.release();
     }
   }
+  async findAll() {
+  const client = await getClient();
+  try {
+    const result = await client.query(`
+      SELECT
+        j.id,
+        j.fecha_jornada AS fecha,
+        u.nombres || ' ' || u.apellidos AS conductor,
+        un.placa || ' - ' || un.marca || ' ' || un.modelo AS camion,
+        c.codigo AS contrato,
+        CASE
+          WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
+            THEN TO_CHAR(j.hora_inicio, 'HH:MI AM') || ' - ' || TO_CHAR(j.hora_fin, 'HH:MI AM')
+          WHEN j.hora_inicio IS NOT NULL
+            THEN TO_CHAR(j.hora_inicio, 'HH:MI AM') || ' - En curso'
+          ELSE 'Sin iniciar'
+        END AS horario,
+        j.km_recorridos AS km,
+        j.estado,
+        j.observaciones
+      FROM jornadas j
+      JOIN usuarios u ON u.id = j.conductor_id
+      JOIN unidades un ON un.id = j.unidad_id
+      JOIN contratos c ON c.id = j.contrato_id
+      ORDER BY j.created_at DESC;
+    `);
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
 }

--- a/src/functions/jornada-services/jornadaService.mjs
+++ b/src/functions/jornada-services/jornadaService.mjs
@@ -115,4 +115,7 @@ export class JornadaService {
     const updated = await this.repository.finishTurn(jornadaId, observaciones);
     return Jornada.fromDatabase(updated);
   }
+  async getAllJornadas() {
+  return this.repository.findAll();
+}
 }


### PR DESCRIPTION
feat: GET /jornadas - listado completo de jornadas HU02

Agrega endpoint GET /jornadas que retorna todas las jornadas con datos
completos (conductor, unidad, contrato, horario, km, estado).

- findAll() en jornadaRepository con JOIN a usuarios, unidades y contratos
- getAllJornadas() en jornadaService
- getAllJornadasController en jornadaController
- Ruta GET /jornadas registrada en jornadaHandler

Closes #52