### PR TITLE
feat(db): actualizar base de datos y compatibilidad backend

### DIFF
--- a/__tests__/helpers/pgMemDb.mjs
+++ b/__tests__/helpers/pgMemDb.mjs
@@ -82,9 +82,9 @@ CREATE TABLE camiones (
 const pgMemSeedSQL = `
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', 'cognito-admin-001', 'admin@nanutech.com', 'Jimena', 'Rodriguez', 'ADMIN', '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'cognito-driver-001', 'chofer1@nanutech.com', 'Carlos', 'Mendoza', 'CHOFER', '999222333', '70000002'),
-('33333333-3333-3333-3333-333333333333', 'cognito-driver-002', 'chofer2@nanutech.com', 'Luis', 'Ramirez', 'CHOFER', '999333444', '70000003');
+('11111111-1111-1111-1111-111111111111', '7438d4b8-0021-7065-dda7-7bbdfa75c929', 'admin@nanutech.com', 'Jimena', 'Rodriguez', 'ADMIN', '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer1@nanutech.com', 'Carlos', 'Mendoza', 'CHOFER', '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002', 'chofer2@nanutech.com', 'Luis', 'Ramirez', 'CHOFER', '999333444', '70000003');
 
 INSERT INTO unidades (id, placa, marca, modelo, anio, capacidad_ton, estado)
 VALUES

--- a/__tests__/helpers/pgMemDb.mjs
+++ b/__tests__/helpers/pgMemDb.mjs
@@ -1,76 +1,130 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { newDb } from "pg-mem";
 import {
   setPoolForTests,
   resetPoolForTests,
 } from "../../src/shared/config/database.mjs";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const pgMemSchemaSQL = `
+CREATE TABLE usuarios (
+  id UUID PRIMARY KEY,
+  cognito_sub VARCHAR(100),
+  correo VARCHAR(120) NOT NULL UNIQUE,
+  nombres VARCHAR(80) NOT NULL,
+  apellidos VARCHAR(80) NOT NULL,
+  rol VARCHAR(20) NOT NULL,
+  telefono VARCHAR(20),
+  dni VARCHAR(15),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  estado VARCHAR(20) NOT NULL DEFAULT 'ACTIVO',
+  ultimo_acceso TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
 
-async function loadSql(fileName) {
-  return fs.readFile(path.join(__dirname, "../../db", fileName), "utf8");
-}
+CREATE TABLE unidades (
+  id UUID PRIMARY KEY,
+  placa VARCHAR(20) NOT NULL UNIQUE,
+  marca VARCHAR(50),
+  modelo VARCHAR(50),
+  anio INTEGER,
+  capacidad_ton NUMERIC(10,2),
+  estado VARCHAR(30) NOT NULL DEFAULT 'DISPONIBLE',
+  gps_habilitado BOOLEAN NOT NULL DEFAULT TRUE,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE contratos (
+  id UUID PRIMARY KEY,
+  codigo VARCHAR(30) NOT NULL UNIQUE,
+  cliente VARCHAR(120) NOT NULL,
+  descripcion TEXT,
+  fecha_inicio DATE NOT NULL,
+  fecha_fin DATE,
+  tarifa NUMERIC(12,2),
+  moneda VARCHAR(10) DEFAULT 'PEN',
+  estado VARCHAR(20) NOT NULL DEFAULT 'VIGENTE',
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE jornadas (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES usuarios(id),
+  unidad_id UUID NOT NULL REFERENCES unidades(id),
+  contrato_id UUID NOT NULL REFERENCES contratos(id),
+  creado_por UUID NOT NULL REFERENCES usuarios(id),
+  fecha_jornada DATE NOT NULL DEFAULT CURRENT_DATE,
+  hora_inicio TIMESTAMP,
+  hora_fin TIMESTAMP,
+  origen VARCHAR(150),
+  destino VARCHAR(150),
+  km_recorridos NUMERIC(10,2) NOT NULL DEFAULT 0,
+  observaciones TEXT,
+  estado VARCHAR(20) NOT NULL DEFAULT 'REGISTRADA',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE camiones (
+  id INTEGER PRIMARY KEY,
+  placa VARCHAR(20) NOT NULL UNIQUE,
+  marca VARCHAR(50),
+  modelo VARCHAR(50),
+  estado VARCHAR(30) NOT NULL DEFAULT 'disponible',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+`;
+
+const pgMemSeedSQL = `
+INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
+VALUES
+('11111111-1111-1111-1111-111111111111', 'cognito-admin-001', 'admin@nanutech.com', 'Jimena', 'Rodriguez', 'ADMIN', '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'cognito-driver-001', 'chofer1@nanutech.com', 'Carlos', 'Mendoza', 'CHOFER', '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-driver-002', 'chofer2@nanutech.com', 'Luis', 'Ramirez', 'CHOFER', '999333444', '70000003');
+
+INSERT INTO unidades (id, placa, marca, modelo, anio, capacidad_ton, estado)
+VALUES
+('aaaa0001-0000-0000-0000-000000000001', 'ABC-123', 'Volvo', 'FH16', 2020, 20.00, 'DISPONIBLE'),
+('aaaa0002-0000-0000-0000-000000000002', 'DEF-456', 'Scania', 'R450', 2021, 18.00, 'EN_JORNADA');
+
+INSERT INTO contratos (id, codigo, cliente, descripcion, fecha_inicio, fecha_fin, tarifa, moneda, estado)
+VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'CONT-2026-001', 'Minera del Sur', 'Transporte de carga minera', '2026-01-01', '2026-12-31', 15000.00, 'PEN', 'VIGENTE');
+
+INSERT INTO jornadas (id, conductor_id, unidad_id, contrato_id, creado_por, fecha_jornada, hora_inicio, origen, destino, km_recorridos, estado)
+VALUES
+('cccc0002-0000-0000-0000-000000000002', '33333333-3333-3333-3333-333333333333', 'aaaa0002-0000-0000-0000-000000000002', 'bbbb0001-0000-0000-0000-000000000001', '11111111-1111-1111-1111-111111111111', '2026-04-26', '2026-04-26 08:00:00', 'Lima', 'Ica', 120.80, 'EN_PROCESO');
+
+INSERT INTO camiones (id, placa, marca, modelo, estado)
+VALUES
+(1, 'ABC-123', 'Volvo', 'FH16', 'disponible'),
+(2, 'DEF-456', 'Scania', 'R450', 'en_uso');
+`;
 
 export async function startPgMem({ seed = true } = {}) {
   const db = newDb({ autoCreateForeignKeyIndices: true });
 
-  // ============================================
-  // REGISTRAR FUNCIONES FALTANTES PARA pg-mem
-  // ============================================
-
-  // 1. Registrar gen_random_uuid() (pgcrypto)
   db.public.registerFunction({
     name: "gen_random_uuid",
     args: [],
     returns: "uuid",
-    implementation: () => {
-      // Generar UUID v4 manualmente
-      return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
-        /[xy]/g,
-        function (c) {
-          const r = (Math.random() * 16) | 0;
-          const v = c === "x" ? r : (r & 0x3) | 0x8;
-          return v.toString(16);
-        },
-      );
-    },
+    implementation: () =>
+      "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+        const r = (Math.random() * 16) | 0;
+        const v = c === "x" ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+      }),
   });
 
-  // 2. Registrar uuid_generate_v4() (uuid-ossp) - por si acaso
-  db.public.registerFunction({
-    name: "uuid_generate_v4",
-    args: [],
-    returns: "uuid",
-    implementation: () => {
-      return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
-        /[xy]/g,
-        function (c) {
-          const r = (Math.random() * 16) | 0;
-          const v = c === "x" ? r : (r & 0x3) | 0x8;
-          return v.toString(16);
-        },
-      );
-    },
-  });
-
-  // 3. Registrar la extensión pgcrypto para que CREATE EXTENSION no falle
-  // Esto hace que pg-mem "finja" que la extensión existe
-  db.registerExtension("pgcrypto", (schema) => {
-    // La extensión ya tiene las funciones registradas arriba
-    // Este callback se ejecuta cuando alguien hace CREATE EXTENSION
-  });
-
-  const schemaSql = await loadSql("schema.sql");
-  const seedSql = await loadSql("seed.sql");
-
-  // Ejecutar el schema (ahora CREATE EXTENSION no fallará)
-  db.public.none(schemaSql);
+  db.registerExtension("pgcrypto", () => {});
+  db.public.none(pgMemSchemaSQL);
 
   if (seed) {
-    db.public.none(seedSql);
+    db.public.none(pgMemSeedSQL);
   }
 
   const { Pool } = db.adapters.createPg();

--- a/__tests__/unit/jornada-services-test/jornadaRepository.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaRepository.test.mjs
@@ -68,7 +68,7 @@ describe("JornadaRepository", () => {
 
     const [query, values] = mockQuery.mock.calls[0];
     expect(query).toContain("conductor_id = $1");
-    expect(query).toContain("estado IN ('REGISTRADA', 'EN_PROCESO')");
+    expect(query).toContain("estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO')");
     expect(values).toEqual(["cond-1"]);
   });
 
@@ -79,7 +79,7 @@ describe("JornadaRepository", () => {
 
     const [query, values] = mockQuery.mock.calls[0];
     expect(query).toContain("unidad_id = $1");
-    expect(query).toContain("estado IN ('REGISTRADA', 'EN_PROCESO')");
+    expect(query).toContain("estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO')");
     expect(values).toEqual(["uni-1"]);
     expect(result).toBe(true);
   });

--- a/db/migrations/1775537760192_sprint1-database.sql
+++ b/db/migrations/1775537760192_sprint1-database.sql
@@ -1,299 +1,1208 @@
 -- ============================================
--- MIGRACIÓN INICIAL - NANUTECH BACKEND
+-- MIGRACION INICIAL - NANUTECH BACKEND
 -- ============================================
 
 -- migrate:up
 
--- ============================================
--- 1. EXTENSIONES
--- ============================================
-
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
--- ============================================
--- 2. TIPOS ENUM
--- ============================================
+-- =========================================================
+-- ENUMS
+-- =========================================================
+CREATE TYPE rol_usuario AS ENUM ('ADMIN', 'CHOFER', 'GERENTE');
+CREATE TYPE estado_usuario AS ENUM ('ACTIVO', 'INACTIVO', 'BLOQUEADO');
 
-DO $$ BEGIN
-    CREATE TYPE rol_usuario AS ENUM ('ADMIN', 'CHOFER');
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+CREATE TYPE estado_operacional_conductor AS ENUM (
+  'DISPONIBLE',
+  'EN_RUTA',
+  'DESCANSO',
+  'LICENCIA',
+  'INACTIVO'
+);
 
-DO $$ BEGIN
-    CREATE TYPE estado_usuario AS ENUM ('ACTIVO', 'INACTIVO', 'BLOQUEADO');
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+CREATE TYPE categoria_licencia AS ENUM (
+  'A-I','A-II-a','A-II-b','A-III-a','A-III-b','A-III-c','C','D','E'
+);
 
-DO $$ BEGIN
-    CREATE TYPE estado_unidad AS ENUM ('DISPONIBLE', 'EN_JORNADA', 'EN_AUXILIO', 'INACTIVA');
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+CREATE TYPE estado_unidad AS ENUM (
+  'DISPONIBLE',
+  'EN_JORNADA',
+  'EN_AUXILIO',
+  'MANTENIMIENTO',
+  'INACTIVA'
+);
 
-DO $$ BEGIN
-    CREATE TYPE estado_contrato AS ENUM ('VIGENTE', 'VENCIDO', 'SUSPENDIDO');
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+CREATE TYPE tipo_combustible AS ENUM (
+  'DIESEL',
+  'GASOLINA',
+  'GNV',
+  'GLP',
+  'ELECTRICO',
+  'HIBRIDO'
+);
 
-DO $$ BEGIN
-    CREATE TYPE estado_jornada AS ENUM ('REGISTRADA', 'EN_PROCESO', 'COMPLETADA', 'CANCELADA');
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+CREATE TYPE estado_contrato AS ENUM (
+  'VIGENTE',
+  'VENCIDO',
+  'SUSPENDIDO',
+  'INACTIVO'
+);
 
-DO $$ BEGIN
-    CREATE TYPE tipo_alerta AS ENUM ('PANICO', 'AUXILIO_MECANICO');
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+CREATE TYPE tipo_servicio_contrato AS ENUM (
+  'POR_VIAJE',
+  'POR_HORA',
+  'POR_TONELADA',
+  'POR_KM',
+  'MENSUAL'
+);
 
-DO $$ BEGIN
-    CREATE TYPE tipo_registro_ubicacion AS ENUM ('INICIO', 'FIN', 'ALERTA', 'TRACKING');
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+CREATE TYPE estado_jornada AS ENUM (
+  'REGISTRADA',
+  'PENDIENTE',
+  'EN_PROCESO',
+  'COMPLETADA',
+  'CANCELADA'
+);
 
--- ============================================
--- 3. TABLAS
--- ============================================
+CREATE TYPE tipo_alerta AS ENUM (
+  'PANICO',
+  'AUXILIO_MECANICO',
+  'OBSERVACION'
+);
 
+CREATE TYPE estado_alerta_operativa AS ENUM (
+  'ACTIVA',
+  'EN_PROCESO',
+  'RESUELTA',
+  'FALSA_ALARMA'
+);
+
+CREATE TYPE severidad_alerta AS ENUM (
+  'BAJA',
+  'MEDIA',
+  'ALTA',
+  'CRITICA'
+);
+
+CREATE TYPE tipo_registro_ubicacion AS ENUM (
+  'INICIO',
+  'FIN',
+  'ALERTA',
+  'TRACKING',
+  'COMBUSTIBLE'
+);
+
+CREATE TYPE proveedor_gps AS ENUM (
+  'GPSCONTROL',
+  'GLOBALGPS',
+  'OTRO'
+);
+
+CREATE TYPE estado_tracking AS ENUM (
+  'MOVIENDO',
+  'DETENIDO',
+  'EXCESO_VELOCIDAD'
+);
+
+CREATE TYPE tipo_evento_gps AS ENUM (
+  'MOVIMIENTO',
+  'DETENCION',
+  'EXCESO_VELOCIDAD',
+  'FUERA_RUTA',
+  'GPS_OFFLINE'
+);
+
+CREATE TYPE tipo_mantenimiento AS ENUM (
+  'PREVENTIVO',
+  'CORRECTIVO',
+  'INSPECCION'
+);
+
+CREATE TYPE estado_asignacion AS ENUM (
+  'ACTIVA',
+  'FINALIZADA',
+  'CANCELADA'
+);
+
+CREATE TYPE estado_importacion AS ENUM (
+  'PENDIENTE',
+  'PROCESADA',
+  'PROCESADA_CON_ERRORES',
+  'RECHAZADA'
+);
+
+CREATE TYPE resultado_auditoria AS ENUM (
+  'EXITOSO',
+  'FALLIDO'
+);
+
+CREATE TYPE estado_sesion AS ENUM (
+  'ACTIVA',
+  'EXPIRADA',
+  'CERRADA',
+  'REVOCADA'
+);
+
+CREATE TYPE tipo_comprobante_combustible AS ENUM (
+  'BOLETA',
+  'FACTURA',
+  'TICKET',
+  'OTRO'
+);
+
+CREATE TYPE estado_combustible AS ENUM (
+  'BORRADOR',
+  'PENDIENTE_SINCRONIZACION',
+  'SINCRONIZADO',
+  'ANULADO'
+);
+
+-- =========================================================
+-- SEGURIDAD / USUARIOS
+-- =========================================================
 CREATE TABLE usuarios (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    cognito_sub VARCHAR(100) UNIQUE,
-    correo VARCHAR(120) NOT NULL UNIQUE,
-    nombres VARCHAR(80) NOT NULL,
-    apellidos VARCHAR(80) NOT NULL,
-    rol rol_usuario NOT NULL,
-    telefono VARCHAR(20),
-    dni VARCHAR(15) UNIQUE,
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    estado estado_usuario NOT NULL DEFAULT 'ACTIVO',
-    ultimo_acceso TIMESTAMP,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cognito_sub VARCHAR(100) UNIQUE,
+  correo VARCHAR(120) NOT NULL UNIQUE,
+  nombres VARCHAR(80) NOT NULL,
+  apellidos VARCHAR(80) NOT NULL,
+  rol rol_usuario NOT NULL,
+  telefono VARCHAR(20),
+  dni VARCHAR(15) UNIQUE,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  estado estado_usuario NOT NULL DEFAULT 'ACTIVO',
+  ultimo_acceso TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE login_intentos (
+  email VARCHAR(120) PRIMARY KEY,
+  intentos_fallidos INTEGER NOT NULL DEFAULT 0,
+  ultimo_intento TIMESTAMP,
+  bloqueado_hasta TIMESTAMP
+);
+
+CREATE TABLE password_reset_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  email VARCHAR(120) NOT NULL,
+  token VARCHAR(255) NOT NULL UNIQUE,
+  expira_at TIMESTAMP NOT NULL,
+  usado BOOLEAN NOT NULL DEFAULT FALSE,
+  usado_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE sesiones_usuario (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID NOT NULL REFERENCES usuarios(id) ON DELETE CASCADE,
+  access_token_jti VARCHAR(255),
+  refresh_token_jti VARCHAR(255),
+  expira_at TIMESTAMP NOT NULL,
+  ultimo_evento_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  estado estado_sesion NOT NULL DEFAULT 'ACTIVA',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE auditoria_accesos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  correo VARCHAR(120),
+  rol rol_usuario,
+  accion VARCHAR(60) NOT NULL,
+  resultado resultado_auditoria NOT NULL,
+  ip_address INET,
+  user_agent TEXT,
+  dispositivo VARCHAR(120),
+  detalle TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- CONDUCTORES
+-- =========================================================
+CREATE TABLE conductores (
+  usuario_id UUID PRIMARY KEY REFERENCES usuarios(id) ON DELETE CASCADE,
+  fecha_nacimiento DATE,
+  direccion VARCHAR(200),
+  fecha_ingreso DATE,
+  estado_operacional estado_operacional_conductor NOT NULL DEFAULT 'DISPONIBLE',
+  current_shift_id UUID,
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE contactos_emergencia (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  nombre VARCHAR(120) NOT NULL,
+  telefono VARCHAR(20) NOT NULL,
+  parentesco VARCHAR(50),
+  es_principal BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE licencias_conducir (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  numero_licencia VARCHAR(40) NOT NULL UNIQUE,
+  categoria categoria_licencia NOT NULL,
+  fecha_emision DATE,
+  fecha_vencimiento DATE NOT NULL,
+  autoridad_emisora VARCHAR(120),
+  activa BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_licencias_fechas
+    CHECK (fecha_emision IS NULL OR fecha_vencimiento >= fecha_emision)
+);
+
+CREATE TABLE conductores_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  campo VARCHAR(80),
+  valor_anterior TEXT,
+  valor_nuevo TEXT,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  ip_address INET,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- GPS / CAMIONES / UNIDADES
+-- =========================================================
+CREATE TABLE gps_dispositivos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo_equipo VARCHAR(50) NOT NULL UNIQUE,
+  proveedor proveedor_gps NOT NULL DEFAULT 'OTRO',
+  imei VARCHAR(30) UNIQUE,
+  numero_sim VARCHAR(30),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  ultima_sincronizacion TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE unidades (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    placa VARCHAR(20) NOT NULL UNIQUE,
-    marca VARCHAR(50),
-    modelo VARCHAR(50),
-    anio INTEGER,
-    capacidad_ton NUMERIC(10,2),
-    estado estado_unidad NOT NULL DEFAULT 'DISPONIBLE',
-    gps_habilitado BOOLEAN NOT NULL DEFAULT TRUE,
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT chk_unidades_anio CHECK (anio IS NULL OR anio BETWEEN 1990 AND 2100),
-    CONSTRAINT chk_unidades_capacidad CHECK (capacidad_ton IS NULL OR capacidad_ton >= 0)
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  placa VARCHAR(20) NOT NULL UNIQUE,
+  marca VARCHAR(50),
+  modelo VARCHAR(50),
+  anio INTEGER,
+  capacidad_ton NUMERIC(10,2),
+  estado estado_unidad NOT NULL DEFAULT 'DISPONIBLE',
+  gps_habilitado BOOLEAN NOT NULL DEFAULT TRUE,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  vin VARCHAR(50) UNIQUE,
+  color VARCHAR(30),
+  tipo_combustible tipo_combustible,
+  fecha_registro DATE,
+  ultima_fecha_mantenimiento DATE,
+  proxima_fecha_mantenimiento DATE,
+  kilometraje_actual NUMERIC(12,2) NOT NULL DEFAULT 0,
+  gps_device_id UUID REFERENCES gps_dispositivos(id) ON DELETE SET NULL,
+  notas TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_unidades_anio CHECK (anio IS NULL OR anio BETWEEN 1990 AND 2100),
+  CONSTRAINT chk_unidades_capacidad CHECK (capacidad_ton IS NULL OR capacidad_ton >= 0),
+  CONSTRAINT chk_unidades_km CHECK (kilometraje_actual >= 0)
 );
 
+-- tabla legacy para tu repo actual src/functions/camion-services/*
+CREATE TABLE camiones (
+  id BIGSERIAL PRIMARY KEY,
+  unidad_id UUID UNIQUE REFERENCES unidades(id) ON DELETE CASCADE,
+  placa VARCHAR(20) NOT NULL UNIQUE,
+  marca VARCHAR(50),
+  modelo VARCHAR(50),
+  estado VARCHAR(30) NOT NULL DEFAULT 'disponible',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE camion_mantenimientos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  tipo tipo_mantenimiento NOT NULL,
+  fecha_programada DATE,
+  fecha_ejecutada DATE,
+  kilometraje NUMERIC(12,2),
+  costo NUMERIC(12,2),
+  proveedor_taller VARCHAR(150),
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE asignaciones_conductor_unidad (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  fecha_inicio TIMESTAMP NOT NULL DEFAULT NOW(),
+  fecha_fin TIMESTAMP,
+  estado estado_asignacion NOT NULL DEFAULT 'ACTIVA',
+  creado_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_asignacion_fechas CHECK (
+    fecha_fin IS NULL OR fecha_fin >= fecha_inicio
+  )
+);
+
+-- =========================================================
+-- CONTRATOS
+-- =========================================================
 CREATE TABLE contratos (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    codigo VARCHAR(30) NOT NULL UNIQUE,
-    cliente VARCHAR(120) NOT NULL,
-    descripcion TEXT,
-    fecha_inicio DATE NOT NULL,
-    fecha_fin DATE,
-    tarifa NUMERIC(12,2),
-    moneda VARCHAR(10) DEFAULT 'PEN',
-    estado estado_contrato NOT NULL DEFAULT 'VIGENTE',
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT chk_contratos_fechas CHECK (fecha_fin IS NULL OR fecha_fin >= fecha_inicio),
-    CONSTRAINT chk_contratos_tarifa CHECK (tarifa IS NULL OR tarifa >= 0)
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) NOT NULL UNIQUE,
+  cliente VARCHAR(120) NOT NULL,
+  ruc VARCHAR(11),
+  descripcion TEXT,
+  tipo_servicio tipo_servicio_contrato NOT NULL DEFAULT 'POR_VIAJE',
+  fecha_inicio DATE NOT NULL,
+  fecha_fin DATE,
+  tarifa NUMERIC(12,2),
+  moneda VARCHAR(10) NOT NULL DEFAULT 'PEN',
+  estado estado_contrato NOT NULL DEFAULT 'VIGENTE',
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  updated_by UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_contratos_fechas CHECK (
+    fecha_fin IS NULL OR fecha_fin >= fecha_inicio
+  ),
+  CONSTRAINT chk_contratos_tarifa CHECK (
+    tarifa IS NULL OR tarifa >= 0
+  ),
+  CONSTRAINT chk_contratos_ruc CHECK (
+    ruc IS NULL OR ruc ~ '^[0-9]{11}$'
+  )
 );
 
+CREATE TABLE contrato_rutas (
+  contrato_id UUID PRIMARY KEY REFERENCES contratos(id) ON DELETE CASCADE,
+  origen VARCHAR(150) NOT NULL,
+  destino VARCHAR(150) NOT NULL,
+  distancia_estimada_km NUMERIC(10,2) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_contrato_distancia CHECK (distancia_estimada_km >= 0)
+);
+
+CREATE TABLE contrato_tarifas (
+  contrato_id UUID PRIMARY KEY REFERENCES contratos(id) ON DELETE CASCADE,
+  tarifa_base NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_km NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_hora NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_tonelada NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_espera NUMERIC(12,2) NOT NULL DEFAULT 0,
+  total_referencial NUMERIC(12,2) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE contrato_unidades (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contrato_id UUID NOT NULL REFERENCES contratos(id) ON DELETE CASCADE,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  assigned_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  assigned_by UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE contratos_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contrato_id UUID NOT NULL REFERENCES contratos(id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  campo VARCHAR(80),
+  valor_anterior TEXT,
+  valor_nuevo TEXT,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  ip_address INET,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- JORNADAS
+-- =========================================================
 CREATE TABLE jornadas (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    conductor_id UUID NOT NULL,
-    unidad_id UUID NOT NULL,
-    contrato_id UUID NOT NULL,
-    creado_por UUID NOT NULL,
-    fecha_jornada DATE NOT NULL DEFAULT CURRENT_DATE,
-    hora_inicio TIMESTAMP NULL,
-    hora_fin TIMESTAMP NULL,
-    origen VARCHAR(150),
-    destino VARCHAR(150),
-    km_recorridos NUMERIC(10,2) NOT NULL DEFAULT 0,
-    observaciones TEXT,
-    estado estado_jornada NOT NULL DEFAULT 'REGISTRADA',
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT fk_jornadas_conductor FOREIGN KEY (conductor_id) REFERENCES usuarios(id),
-    CONSTRAINT fk_jornadas_unidad FOREIGN KEY (unidad_id) REFERENCES unidades(id),
-    CONSTRAINT fk_jornadas_contrato FOREIGN KEY (contrato_id) REFERENCES contratos(id),
-    CONSTRAINT fk_jornadas_creado_por FOREIGN KEY (creado_por) REFERENCES usuarios(id),
-    CONSTRAINT chk_jornadas_horas CHECK (hora_fin IS NULL OR hora_inicio IS NULL OR hora_fin >= hora_inicio),
-    CONSTRAINT chk_jornadas_km CHECK (km_recorridos >= 0)
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) UNIQUE,
+  conductor_id UUID NOT NULL REFERENCES usuarios(id),
+  unidad_id UUID NOT NULL REFERENCES unidades(id),
+  contrato_id UUID NOT NULL REFERENCES contratos(id),
+  creado_por UUID NOT NULL REFERENCES usuarios(id),
+  fecha_jornada DATE NOT NULL DEFAULT CURRENT_DATE,
+  hora_inicio_programada TIMESTAMP,
+  hora_fin_programada TIMESTAMP,
+  hora_inicio TIMESTAMP,
+  hora_fin TIMESTAMP,
+  origen VARCHAR(150),
+  destino VARCHAR(150),
+  km_estimados NUMERIC(10,2) NOT NULL DEFAULT 0,
+  km_recorridos NUMERIC(10,2) NOT NULL DEFAULT 0,
+  tipo_carga VARCHAR(120),
+  peso_carga_ton NUMERIC(10,2),
+  observaciones VARCHAR(500),
+  observacion_admin TEXT,
+  estado estado_jornada NOT NULL DEFAULT 'REGISTRADA',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_jornadas_horas CHECK (
+    hora_fin IS NULL OR hora_inicio IS NULL OR hora_fin >= hora_inicio
+  ),
+  CONSTRAINT chk_jornadas_horas_programadas CHECK (
+    hora_fin_programada IS NULL OR hora_inicio_programada IS NULL OR hora_fin_programada >= hora_inicio_programada
+  ),
+  CONSTRAINT chk_jornadas_km CHECK (
+    km_estimados >= 0 AND km_recorridos >= 0
+  ),
+  CONSTRAINT chk_jornadas_peso CHECK (
+    peso_carga_ton IS NULL OR peso_carga_ton >= 0
+  )
 );
 
+ALTER TABLE conductores
+  ADD CONSTRAINT fk_conductores_current_shift
+  FOREIGN KEY (current_shift_id) REFERENCES jornadas(id) ON DELETE SET NULL;
+
+-- =========================================================
+-- ALERTAS Y AUXILIO
+-- =========================================================
 CREATE TABLE alertas_jornada (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    jornada_id UUID NOT NULL,
-    tipo tipo_alerta NOT NULL,
-    detalle TEXT,
-    latitud NUMERIC(10,7) NOT NULL,
-    longitud NUMERIC(10,7) NOT NULL,
-    fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
-    atendida BOOLEAN NOT NULL DEFAULT FALSE,
-    atendida_por UUID NULL,
-    atendida_at TIMESTAMP NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT fk_alertas_jornada FOREIGN KEY (jornada_id) REFERENCES jornadas(id) ON DELETE CASCADE,
-    CONSTRAINT fk_alertas_atendida_por FOREIGN KEY (atendida_por) REFERENCES usuarios(id),
-    CONSTRAINT chk_alertas_latitud CHECK (latitud BETWEEN -90 AND 90),
-    CONSTRAINT chk_alertas_longitud CHECK (longitud BETWEEN -180 AND 180),
-    CONSTRAINT chk_alertas_atencion CHECK (
-        (atendida = FALSE) OR (atendida = TRUE AND atendida_at IS NOT NULL)
-    )
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) UNIQUE,
+  jornada_id UUID NOT NULL REFERENCES jornadas(id) ON DELETE CASCADE,
+  tipo tipo_alerta NOT NULL,
+  estado estado_alerta_operativa NOT NULL DEFAULT 'ACTIVA',
+  severidad severidad_alerta NOT NULL DEFAULT 'MEDIA',
+  detalle TEXT,
+  tipo_falla_mecanica VARCHAR(120),
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  direccion VARCHAR(200),
+  fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
+  atendida BOOLEAN NOT NULL DEFAULT FALSE,
+  atendida_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  atendida_at TIMESTAMP,
+  detalle_resolucion TEXT,
+  servicio_tecnico_realizado TEXT,
+  telefono_contactado VARCHAR(20),
+  bloqueo_sos_activo BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_alertas_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_alertas_longitud CHECK (longitud BETWEEN -180 AND 180),
+  CONSTRAINT chk_alertas_atencion CHECK (
+    (atendida = FALSE)
+    OR (atendida = TRUE AND atendida_at IS NOT NULL)
+  )
 );
 
+CREATE TABLE alertas_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  alerta_id UUID NOT NULL REFERENCES alertas_jornada(id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- UBICACIONES / GPS
+-- =========================================================
 CREATE TABLE ubicaciones_jornada (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    jornada_id UUID NOT NULL,
-    latitud NUMERIC(10,7) NOT NULL,
-    longitud NUMERIC(10,7) NOT NULL,
-    fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
-    tipo_registro tipo_registro_ubicacion NOT NULL,
-    velocidad_kmh NUMERIC(8,2),
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT fk_ubicaciones_jornada FOREIGN KEY (jornada_id) REFERENCES jornadas(id) ON DELETE CASCADE,
-    CONSTRAINT chk_ubicaciones_latitud CHECK (latitud BETWEEN -90 AND 90),
-    CONSTRAINT chk_ubicaciones_longitud CHECK (longitud BETWEEN -180 AND 180),
-    CONSTRAINT chk_ubicaciones_velocidad CHECK (velocidad_kmh IS NULL OR velocidad_kmh >= 0)
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  jornada_id UUID NOT NULL REFERENCES jornadas(id) ON DELETE CASCADE,
+  unidad_id UUID REFERENCES unidades(id) ON DELETE SET NULL,
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  direccion VARCHAR(200),
+  fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
+  tipo_registro tipo_registro_ubicacion NOT NULL,
+  velocidad_kmh NUMERIC(8,2),
+  rumbo NUMERIC(6,2),
+  odometro_km NUMERIC(12,2),
+  proveedor proveedor_gps,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_ubicaciones_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_ubicaciones_longitud CHECK (longitud BETWEEN -180 AND 180),
+  CONSTRAINT chk_ubicaciones_velocidad CHECK (
+    velocidad_kmh IS NULL OR velocidad_kmh >= 0
+  )
 );
 
--- ============================================
--- 4. ÍNDICES
--- ============================================
+CREATE TABLE gps_importaciones (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  proveedor proveedor_gps NOT NULL,
+  nombre_archivo VARCHAR(255) NOT NULL,
+  cargado_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  total_registros INTEGER NOT NULL DEFAULT 0,
+  registros_validos INTEGER NOT NULL DEFAULT 0,
+  registros_invalidos INTEGER NOT NULL DEFAULT 0,
+  estado estado_importacion NOT NULL DEFAULT 'PENDIENTE',
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  processed_at TIMESTAMP
+);
 
+CREATE TABLE gps_importacion_errores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  importacion_id UUID NOT NULL REFERENCES gps_importaciones(id) ON DELETE CASCADE,
+  numero_fila INTEGER NOT NULL,
+  campo VARCHAR(80),
+  valor_recibido TEXT,
+  motivo_error TEXT NOT NULL,
+  raw_payload JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE gps_proveedor_formatos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  proveedor VARCHAR(80) NOT NULL,
+  nombre_formato VARCHAR(120) NOT NULL,
+  mapeo_columnas JSONB NOT NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_gps_proveedor_formato UNIQUE (proveedor, nombre_formato)
+);
+
+CREATE TABLE gps_registros (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  importacion_id UUID REFERENCES gps_importaciones(id) ON DELETE SET NULL,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  fecha_hora TIMESTAMP NOT NULL,
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  velocidad_kmh NUMERIC(8,2),
+  rumbo NUMERIC(6,2),
+  odometro_km NUMERIC(12,2),
+  estado estado_tracking,
+  proveedor proveedor_gps NOT NULL,
+  raw_payload JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_gps_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_gps_longitud CHECK (longitud BETWEEN -180 AND 180)
+);
+
+CREATE TABLE gps_eventos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  tipo_evento tipo_evento_gps NOT NULL,
+  estado estado_tracking,
+  fecha_hora_inicio TIMESTAMP NOT NULL,
+  fecha_hora_fin TIMESTAMP,
+  velocidad_maxima NUMERIC(8,2),
+  latitud NUMERIC(10,7),
+  longitud NUMERIC(10,7),
+  distancia_km NUMERIC(10,2),
+  detalle TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_gps_evento_fechas CHECK (
+    fecha_hora_fin IS NULL OR fecha_hora_fin >= fecha_hora_inicio
+  )
+);
+
+-- =========================================================
+-- COMBUSTIBLE
+-- =========================================================
+CREATE TABLE combustible_registros (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  contrato_id UUID REFERENCES contratos(id) ON DELETE SET NULL,
+  tipo_comprobante tipo_comprobante_combustible DEFAULT 'TICKET',
+  numero_comprobante VARCHAR(50),
+  galones NUMERIC(10,2) NOT NULL,
+  costo_total NUMERIC(12,2) NOT NULL,
+  kilometraje_actual NUMERIC(12,2) NOT NULL,
+  kilometraje_anterior NUMERIC(12,2) DEFAULT 0,
+  rendimiento_km_galon NUMERIC(10,2),
+  foto_comprobante_url TEXT,
+  observaciones TEXT,
+  latitud NUMERIC(10,7),
+  longitud NUMERIC(10,7),
+  estado estado_combustible NOT NULL DEFAULT 'SINCRONIZADO',
+  sincronizado BOOLEAN NOT NULL DEFAULT TRUE,
+  registrado_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_combustible_galones CHECK (galones > 0),
+  CONSTRAINT chk_combustible_costo CHECK (costo_total >= 0),
+  CONSTRAINT chk_combustible_km CHECK (kilometraje_actual >= kilometraje_anterior)
+);
+
+-- =========================================================
+-- ÍNDICES
+-- =========================================================
 CREATE INDEX idx_usuarios_rol ON usuarios(rol);
 CREATE INDEX idx_usuarios_estado ON usuarios(estado);
+
+CREATE INDEX idx_sesiones_usuario ON sesiones_usuario(usuario_id);
+CREATE INDEX idx_sesiones_estado ON sesiones_usuario(estado);
+CREATE INDEX idx_reset_email ON password_reset_tokens(email);
+CREATE INDEX idx_auditoria_usuario ON auditoria_accesos(usuario_id);
+CREATE INDEX idx_auditoria_fecha ON auditoria_accesos(created_at);
+
+CREATE INDEX idx_conductores_estado_operacional ON conductores(estado_operacional);
+CREATE INDEX idx_contactos_emergencia_conductor ON contactos_emergencia(conductor_id);
+CREATE INDEX idx_licencias_conductor ON licencias_conducir(conductor_id);
+CREATE INDEX idx_licencias_vencimiento ON licencias_conducir(fecha_vencimiento);
+
 CREATE INDEX idx_unidades_estado ON unidades(estado);
+CREATE INDEX idx_unidades_gps_device ON unidades(gps_device_id);
+CREATE INDEX idx_camiones_unidad_id ON camiones(unidad_id);
+CREATE INDEX idx_camiones_estado ON camiones(estado);
+CREATE INDEX idx_mantenimientos_unidad ON camion_mantenimientos(unidad_id);
+
+CREATE INDEX idx_asignaciones_conductor ON asignaciones_conductor_unidad(conductor_id);
+CREATE INDEX idx_asignaciones_unidad ON asignaciones_conductor_unidad(unidad_id);
+CREATE UNIQUE INDEX uq_asignacion_activa_conductor
+  ON asignaciones_conductor_unidad(conductor_id)
+  WHERE estado = 'ACTIVA';
+CREATE UNIQUE INDEX uq_asignacion_activa_unidad
+  ON asignaciones_conductor_unidad(unidad_id)
+  WHERE estado = 'ACTIVA';
+
 CREATE INDEX idx_contratos_estado ON contratos(estado);
+CREATE INDEX idx_contratos_tipo_servicio ON contratos(tipo_servicio);
+CREATE UNIQUE INDEX uq_contrato_unidad_activa
+  ON contrato_unidades(contrato_id, unidad_id)
+  WHERE activo = TRUE;
+
 CREATE INDEX idx_jornadas_fecha ON jornadas(fecha_jornada);
 CREATE INDEX idx_jornadas_estado ON jornadas(estado);
 CREATE INDEX idx_jornadas_conductor ON jornadas(conductor_id);
 CREATE INDEX idx_jornadas_unidad ON jornadas(unidad_id);
 CREATE INDEX idx_jornadas_contrato ON jornadas(contrato_id);
+CREATE UNIQUE INDEX uq_jornada_activa_unidad
+  ON jornadas(unidad_id)
+  WHERE estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO');
+CREATE UNIQUE INDEX uq_jornada_activa_chofer
+  ON jornadas(conductor_id)
+  WHERE estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO');
+
 CREATE INDEX idx_alertas_jornada ON alertas_jornada(jornada_id);
 CREATE INDEX idx_alertas_tipo ON alertas_jornada(tipo);
+CREATE INDEX idx_alertas_estado ON alertas_jornada(estado);
 CREATE INDEX idx_alertas_fecha_hora ON alertas_jornada(fecha_hora);
+CREATE INDEX idx_alertas_historial_alerta ON alertas_historial(alerta_id);
+
 CREATE INDEX idx_ubicaciones_jornada ON ubicaciones_jornada(jornada_id);
+CREATE INDEX idx_ubicaciones_unidad ON ubicaciones_jornada(unidad_id);
 CREATE INDEX idx_ubicaciones_fecha_hora ON ubicaciones_jornada(fecha_hora);
 
-CREATE UNIQUE INDEX uq_jornada_activa_unidad ON jornadas (unidad_id)
-    WHERE estado IN ('REGISTRADA', 'EN_PROCESO');
+CREATE INDEX idx_gps_importacion_errores_importacion ON gps_importacion_errores(importacion_id);
+CREATE INDEX idx_gps_registros_unidad ON gps_registros(unidad_id);
+CREATE INDEX idx_gps_registros_jornada ON gps_registros(jornada_id);
+CREATE INDEX idx_gps_registros_fecha_hora ON gps_registros(fecha_hora);
+CREATE UNIQUE INDEX uq_gps_registros_proveedor_unidad_fecha
+  ON gps_registros(proveedor, unidad_id, fecha_hora);
+CREATE INDEX idx_gps_eventos_unidad ON gps_eventos(unidad_id);
+CREATE INDEX idx_gps_eventos_jornada ON gps_eventos(jornada_id);
+CREATE INDEX idx_gps_eventos_tipo ON gps_eventos(tipo_evento);
 
-CREATE UNIQUE INDEX uq_jornada_activa_chofer ON jornadas (conductor_id)
-    WHERE estado IN ('REGISTRADA', 'EN_PROCESO');
+CREATE INDEX idx_combustible_unidad ON combustible_registros(unidad_id);
+CREATE INDEX idx_combustible_conductor ON combustible_registros(conductor_id);
+CREATE INDEX idx_combustible_jornada ON combustible_registros(jornada_id);
 
--- ============================================
--- 5. FUNCIONES Y TRIGGERS
--- ============================================
-
+-- =========================================================
+-- TRIGGER GENERICO updated_at
+-- =========================================================
 CREATE OR REPLACE FUNCTION fn_set_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.updated_at = NOW();
-    RETURN NEW;
+  NEW.updated_at = NOW();
+  RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER tg_usuarios_updated_at
-    BEFORE UPDATE ON usuarios
-    FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+BEFORE UPDATE ON usuarios
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_conductores_updated_at
+BEFORE UPDATE ON conductores
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_licencias_updated_at
+BEFORE UPDATE ON licencias_conducir
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_gps_dispositivos_updated_at
+BEFORE UPDATE ON gps_dispositivos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_gps_proveedor_formatos_updated_at
+BEFORE UPDATE ON gps_proveedor_formatos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
 
 CREATE TRIGGER tg_unidades_updated_at
-    BEFORE UPDATE ON unidades
-    FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+BEFORE UPDATE ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_camiones_updated_at
+BEFORE UPDATE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_mantenimientos_updated_at
+BEFORE UPDATE ON camion_mantenimientos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
 
 CREATE TRIGGER tg_contratos_updated_at
-    BEFORE UPDATE ON contratos
-    FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+BEFORE UPDATE ON contratos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
 
 CREATE TRIGGER tg_jornadas_updated_at
-    BEFORE UPDATE ON jornadas
-    FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+BEFORE UPDATE ON jornadas
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
 
--- ============================================
--- 6. VISTAS
--- ============================================
+-- =========================================================
+-- SINCRONIZACION unidades <-> camiones
+-- =========================================================
+CREATE OR REPLACE FUNCTION fn_map_camion_estado_to_unidad(p_estado TEXT)
+RETURNS estado_unidad AS $$
+BEGIN
+  RETURN CASE LOWER(COALESCE(p_estado, 'disponible'))
+    WHEN 'disponible' THEN 'DISPONIBLE'
+    WHEN 'available' THEN 'DISPONIBLE'
+    WHEN 'activo' THEN 'DISPONIBLE'
+    WHEN 'active' THEN 'DISPONIBLE'
+    WHEN 'en_uso' THEN 'EN_JORNADA'
+    WHEN 'in_use' THEN 'EN_JORNADA'
+    WHEN 'en_jornada' THEN 'EN_JORNADA'
+    WHEN 'en_auxilio' THEN 'EN_AUXILIO'
+    WHEN 'auxilio' THEN 'EN_AUXILIO'
+    WHEN 'mantenimiento' THEN 'MANTENIMIENTO'
+    WHEN 'maintenance' THEN 'MANTENIMIENTO'
+    ELSE 'INACTIVA'
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION fn_map_unidad_estado_to_camion(p_estado estado_unidad)
+RETURNS TEXT AS $$
+BEGIN
+  RETURN CASE p_estado
+    WHEN 'DISPONIBLE' THEN 'disponible'
+    WHEN 'EN_JORNADA' THEN 'en_uso'
+    WHEN 'EN_AUXILIO' THEN 'en_auxilio'
+    WHEN 'MANTENIMIENTO' THEN 'maintenance'
+    ELSE 'inactivo'
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION fn_sync_unidad_to_camion()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    ELSE
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO camiones (unidad_id, placa, marca, modelo, estado, created_at, updated_at)
+    VALUES (
+      NEW.id,
+      NEW.placa,
+      NEW.marca,
+      NEW.modelo,
+      fn_map_unidad_estado_to_camion(NEW.estado),
+      NEW.created_at,
+      NEW.updated_at
+    )
+    ON CONFLICT (unidad_id) DO UPDATE
+      SET placa = EXCLUDED.placa,
+          marca = EXCLUDED.marca,
+          modelo = EXCLUDED.modelo,
+          estado = EXCLUDED.estado,
+          updated_at = NOW();
+    RETURN NEW;
+  ELSIF TG_OP = 'UPDATE' THEN
+    UPDATE camiones
+       SET placa = NEW.placa,
+           marca = NEW.marca,
+           modelo = NEW.modelo,
+           estado = fn_map_unidad_estado_to_camion(NEW.estado),
+           updated_at = NOW()
+     WHERE unidad_id = NEW.id;
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    DELETE FROM camiones WHERE unidad_id = OLD.id;
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_before_insert()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_unidad_id UUID;
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.unidad_id IS NULL THEN
+    INSERT INTO unidades (
+      placa, marca, modelo, estado, gps_habilitado, activo, created_at, updated_at
+    )
+    VALUES (
+      NEW.placa,
+      NEW.marca,
+      NEW.modelo,
+      fn_map_camion_estado_to_unidad(NEW.estado),
+      TRUE,
+      TRUE,
+      COALESCE(NEW.created_at, NOW()),
+      COALESCE(NEW.updated_at, NOW())
+    )
+    RETURNING id INTO v_unidad_id;
+
+    NEW.unidad_id := v_unidad_id;
+  END IF;
+
+  NEW.created_at := COALESCE(NEW.created_at, NOW());
+  NEW.updated_at := COALESCE(NEW.updated_at, NOW());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_after_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE unidades
+     SET placa = NEW.placa,
+         marca = NEW.marca,
+         modelo = NEW.modelo,
+         estado = fn_map_camion_estado_to_unidad(NEW.estado),
+         updated_at = NOW()
+   WHERE id = NEW.unidad_id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_after_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN OLD;
+  END IF;
+
+  DELETE FROM unidades WHERE id = OLD.unidad_id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tg_unidad_to_camion_ins
+AFTER INSERT ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_unidad_to_camion_upd
+AFTER UPDATE ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_unidad_to_camion_del
+AFTER DELETE ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_camion_before_insert
+BEFORE INSERT ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_before_insert();
+
+CREATE TRIGGER tg_camion_after_update
+AFTER UPDATE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_after_update();
+
+CREATE TRIGGER tg_camion_after_delete
+AFTER DELETE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_after_delete();
+
+-- =========================================================
+-- VISTAS
+-- =========================================================
+CREATE OR REPLACE VIEW vw_conductores_full AS
+SELECT
+  u.id AS usuario_id,
+  u.cognito_sub,
+  u.correo,
+  u.nombres,
+  u.apellidos,
+  CONCAT(u.nombres, ' ', u.apellidos) AS nombre_completo,
+  u.telefono,
+  u.dni,
+  u.rol,
+  u.estado AS estado_usuario,
+  c.fecha_nacimiento,
+  c.direccion,
+  c.fecha_ingreso,
+  c.estado_operacional,
+  c.current_shift_id,
+  lc.numero_licencia,
+  lc.categoria AS licencia_categoria,
+  lc.fecha_vencimiento AS licencia_vencimiento,
+  ce.nombre AS contacto_emergencia_nombre,
+  ce.telefono AS contacto_emergencia_telefono,
+  ce.parentesco AS contacto_emergencia_parentesco,
+  a.unidad_id AS unidad_asignada_id,
+  un.placa AS placa_asignada
+FROM usuarios u
+JOIN conductores c ON c.usuario_id = u.id
+LEFT JOIN LATERAL (
+  SELECT l.*
+  FROM licencias_conducir l
+  WHERE l.conductor_id = c.usuario_id AND l.activa = TRUE
+  ORDER BY l.fecha_vencimiento DESC
+  LIMIT 1
+) lc ON TRUE
+LEFT JOIN LATERAL (
+  SELECT x.*
+  FROM contactos_emergencia x
+  WHERE x.conductor_id = c.usuario_id AND x.es_principal = TRUE
+  ORDER BY x.created_at DESC
+  LIMIT 1
+) ce ON TRUE
+LEFT JOIN LATERAL (
+  SELECT ac.*
+  FROM asignaciones_conductor_unidad ac
+  WHERE ac.conductor_id = c.usuario_id AND ac.estado = 'ACTIVA'
+  ORDER BY ac.fecha_inicio DESC
+  LIMIT 1
+) a ON TRUE
+LEFT JOIN unidades un ON un.id = a.unidad_id
+WHERE u.rol = 'CHOFER';
+
+CREATE OR REPLACE VIEW vw_camiones_operativos AS
+SELECT
+  un.id AS unidad_id,
+  c.id AS camion_legacy_id,
+  un.placa,
+  un.marca,
+  un.modelo,
+  un.anio,
+  un.capacidad_ton,
+  un.estado,
+  un.activo,
+  un.vin,
+  un.color,
+  un.tipo_combustible,
+  un.kilometraje_actual,
+  un.gps_habilitado,
+  gd.codigo_equipo AS gps_codigo_equipo,
+  gd.proveedor AS gps_proveedor,
+  un.ultima_fecha_mantenimiento,
+  un.proxima_fecha_mantenimiento
+FROM unidades un
+LEFT JOIN camiones c ON c.unidad_id = un.id
+LEFT JOIN gps_dispositivos gd ON gd.id = un.gps_device_id;
+
+CREATE OR REPLACE VIEW vw_historial_jornadas_chofer AS
+SELECT
+  j.id,
+  j.codigo,
+  j.conductor_id,
+  j.fecha_jornada,
+  j.origen,
+  j.destino,
+  j.hora_inicio,
+  j.hora_fin,
+  CASE
+    WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
+    THEN (j.hora_fin - j.hora_inicio)
+    ELSE NULL
+  END AS duracion_total,
+  j.km_recorridos,
+  j.observaciones,
+  j.estado,
+  j.unidad_id,
+  un.placa
+FROM jornadas j
+JOIN unidades un ON un.id = j.unidad_id
+WHERE j.estado = 'COMPLETADA';
 
 CREATE OR REPLACE VIEW vw_seguimiento_jornadas AS
 SELECT
-    j.id,
-    j.fecha_jornada,
-    CONCAT(u.nombres, ' ', u.apellidos) AS nombre_chofer,
-    un.placa AS placa_camion,
-    c.codigo AS codigo_contrato,
-    c.cliente,
-    j.origen,
-    j.destino,
-    j.hora_inicio,
-    j.hora_fin,
-    CASE
-        WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
-            THEN (j.hora_fin - j.hora_inicio)
-        ELSE NULL
-    END AS duracion_total,
-    j.km_recorridos,
-    j.estado,
-    j.observaciones,
-    EXISTS (
-        SELECT 1 FROM alertas_jornada a
-        WHERE a.jornada_id = j.id AND a.tipo = 'PANICO'
-    ) AS tiene_panico,
-    EXISTS (
-        SELECT 1 FROM alertas_jornada a
-        WHERE a.jornada_id = j.id AND a.tipo = 'AUXILIO_MECANICO'
-    ) AS tiene_auxilio,
-    (SELECT COUNT(*) FROM alertas_jornada a WHERE a.jornada_id = j.id) AS total_alertas
+  j.id,
+  j.codigo,
+  j.fecha_jornada,
+  j.conductor_id,
+  CONCAT(u.nombres, ' ', u.apellidos) AS nombre_chofer,
+  j.unidad_id,
+  un.placa AS placa_camion,
+  un.marca,
+  un.modelo,
+  j.contrato_id,
+  c.codigo AS codigo_contrato,
+  c.cliente,
+  j.origen,
+  j.destino,
+  j.hora_inicio,
+  j.hora_fin,
+  CASE
+    WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
+    THEN (j.hora_fin - j.hora_inicio)
+    ELSE NULL
+  END AS duracion_total,
+  j.km_estimados,
+  j.km_recorridos,
+  j.estado,
+  j.observaciones,
+  EXISTS (
+    SELECT 1 FROM alertas_jornada a
+    WHERE a.jornada_id = j.id AND a.tipo = 'PANICO'
+  ) AS tiene_panico,
+  EXISTS (
+    SELECT 1 FROM alertas_jornada a
+    WHERE a.jornada_id = j.id AND a.tipo = 'AUXILIO_MECANICO'
+  ) AS tiene_auxilio,
+  (SELECT COUNT(*) FROM alertas_jornada a WHERE a.jornada_id = j.id) AS total_alertas
 FROM jornadas j
-INNER JOIN usuarios u ON u.id = j.conductor_id
-INNER JOIN unidades un ON un.id = j.unidad_id
-INNER JOIN contratos c ON c.id = j.contrato_id
+JOIN usuarios u ON u.id = j.conductor_id
+JOIN unidades un ON un.id = j.unidad_id
+JOIN contratos c ON c.id = j.contrato_id
 ORDER BY j.fecha_jornada DESC, j.created_at DESC;
 
--- ============================================
+CREATE OR REPLACE VIEW vw_tracking_gps AS
+SELECT
+  gr.id,
+  gr.unidad_id,
+  un.placa,
+  gr.jornada_id,
+  gr.fecha_hora,
+  gr.latitud,
+  gr.longitud,
+  gr.rumbo,
+  gr.velocidad_kmh,
+  gr.estado,
+  gr.odometro_km,
+  gr.proveedor
+FROM gps_registros gr
+JOIN unidades un ON un.id = gr.unidad_id;
+
+CREATE OR REPLACE VIEW vw_alertas_panel AS
+SELECT
+  a.id,
+  a.codigo,
+  a.jornada_id,
+  a.tipo,
+  a.estado,
+  a.severidad,
+  a.detalle,
+  a.tipo_falla_mecanica,
+  a.latitud,
+  a.longitud,
+  a.direccion,
+  a.fecha_hora,
+  a.atendida,
+  a.atendida_at,
+  j.unidad_id,
+  un.placa,
+  CONCAT(u.nombres, ' ', u.apellidos) AS conductor
+FROM alertas_jornada a
+JOIN jornadas j ON j.id = a.jornada_id
+JOIN unidades un ON un.id = j.unidad_id
+JOIN usuarios u ON u.id = j.conductor_id
+ORDER BY a.fecha_hora DESC;
+
+CREATE OR REPLACE VIEW vw_dashboard_resumen AS
+SELECT
+  (SELECT COUNT(*) FROM unidades WHERE activo = TRUE) AS total_camiones,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'EN_JORNADA') AS camiones_en_uso,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'DISPONIBLE') AS camiones_disponibles,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'MANTENIMIENTO') AS camiones_mantenimiento,
+  (SELECT COUNT(*) FROM usuarios WHERE rol = 'CHOFER' AND activo = TRUE) AS total_conductores,
+  (SELECT COUNT(*) FROM conductores WHERE estado_operacional = 'EN_RUTA') AS conductores_en_ruta,
+  (SELECT COUNT(*) FROM contratos WHERE estado = 'VIGENTE' AND activo = TRUE) AS contratos_activos,
+  (SELECT COUNT(*) FROM jornadas WHERE estado IN ('REGISTRADA','PENDIENTE','EN_PROCESO')) AS jornadas_activas,
+  (SELECT COUNT(*) FROM alertas_jornada WHERE estado IN ('ACTIVA','EN_PROCESO')) AS alertas_activas,
+  (SELECT COALESCE(SUM(km_recorridos), 0) FROM jornadas WHERE estado = 'COMPLETADA') AS km_totales_operados;
+
+
 -- migrate:down
--- ============================================
 
+DROP VIEW IF EXISTS vw_dashboard_resumen CASCADE;
+DROP VIEW IF EXISTS vw_alertas_panel CASCADE;
+DROP VIEW IF EXISTS vw_tracking_gps CASCADE;
 DROP VIEW IF EXISTS vw_seguimiento_jornadas CASCADE;
+DROP VIEW IF EXISTS vw_historial_jornadas_chofer CASCADE;
+DROP VIEW IF EXISTS vw_camiones_operativos CASCADE;
+DROP VIEW IF EXISTS vw_conductores_full CASCADE;
 
-DROP TRIGGER IF EXISTS tg_jornadas_updated_at ON jornadas CASCADE;
-DROP TRIGGER IF EXISTS tg_contratos_updated_at ON contratos CASCADE;
-DROP TRIGGER IF EXISTS tg_unidades_updated_at ON unidades CASCADE;
-DROP TRIGGER IF EXISTS tg_usuarios_updated_at ON usuarios CASCADE;
-DROP FUNCTION IF EXISTS fn_set_updated_at CASCADE;
+DROP FUNCTION IF EXISTS fn_sync_camion_after_delete() CASCADE;
+DROP FUNCTION IF EXISTS fn_sync_camion_after_update() CASCADE;
+DROP FUNCTION IF EXISTS fn_sync_camion_before_insert() CASCADE;
+DROP FUNCTION IF EXISTS fn_sync_unidad_to_camion() CASCADE;
+DROP FUNCTION IF EXISTS fn_map_unidad_estado_to_camion(estado_unidad) CASCADE;
+DROP FUNCTION IF EXISTS fn_map_camion_estado_to_unidad(TEXT) CASCADE;
+DROP FUNCTION IF EXISTS fn_set_updated_at() CASCADE;
 
-DROP INDEX IF EXISTS uq_jornada_activa_chofer CASCADE;
-DROP INDEX IF EXISTS uq_jornada_activa_unidad CASCADE;
-DROP INDEX IF EXISTS idx_ubicaciones_fecha_hora CASCADE;
-DROP INDEX IF EXISTS idx_ubicaciones_jornada CASCADE;
-DROP INDEX IF EXISTS idx_alertas_fecha_hora CASCADE;
-DROP INDEX IF EXISTS idx_alertas_tipo CASCADE;
-DROP INDEX IF EXISTS idx_alertas_jornada CASCADE;
-DROP INDEX IF EXISTS idx_jornadas_contrato CASCADE;
-DROP INDEX IF EXISTS idx_jornadas_unidad CASCADE;
-DROP INDEX IF EXISTS idx_jornadas_conductor CASCADE;
-DROP INDEX IF EXISTS idx_jornadas_estado CASCADE;
-DROP INDEX IF EXISTS idx_jornadas_fecha CASCADE;
-DROP INDEX IF EXISTS idx_contratos_estado CASCADE;
-DROP INDEX IF EXISTS idx_unidades_estado CASCADE;
-DROP INDEX IF EXISTS idx_usuarios_estado CASCADE;
-DROP INDEX IF EXISTS idx_usuarios_rol CASCADE;
-
+DROP TABLE IF EXISTS combustible_registros CASCADE;
+DROP TABLE IF EXISTS gps_eventos CASCADE;
+DROP TABLE IF EXISTS gps_registros CASCADE;
+DROP TABLE IF EXISTS gps_importacion_errores CASCADE;
+DROP TABLE IF EXISTS gps_proveedor_formatos CASCADE;
+DROP TABLE IF EXISTS gps_importaciones CASCADE;
 DROP TABLE IF EXISTS ubicaciones_jornada CASCADE;
+DROP TABLE IF EXISTS alertas_historial CASCADE;
 DROP TABLE IF EXISTS alertas_jornada CASCADE;
 DROP TABLE IF EXISTS jornadas CASCADE;
+DROP TABLE IF EXISTS contratos_historial CASCADE;
+DROP TABLE IF EXISTS contrato_unidades CASCADE;
+DROP TABLE IF EXISTS contrato_tarifas CASCADE;
+DROP TABLE IF EXISTS contrato_rutas CASCADE;
 DROP TABLE IF EXISTS contratos CASCADE;
+DROP TABLE IF EXISTS asignaciones_conductor_unidad CASCADE;
+DROP TABLE IF EXISTS camion_mantenimientos CASCADE;
+DROP TABLE IF EXISTS camiones CASCADE;
 DROP TABLE IF EXISTS unidades CASCADE;
+DROP TABLE IF EXISTS gps_dispositivos CASCADE;
+DROP TABLE IF EXISTS conductores_historial CASCADE;
+DROP TABLE IF EXISTS licencias_conducir CASCADE;
+DROP TABLE IF EXISTS contactos_emergencia CASCADE;
+DROP TABLE IF EXISTS conductores CASCADE;
+DROP TABLE IF EXISTS auditoria_accesos CASCADE;
+DROP TABLE IF EXISTS sesiones_usuario CASCADE;
+DROP TABLE IF EXISTS password_reset_tokens CASCADE;
+DROP TABLE IF EXISTS login_intentos CASCADE;
 DROP TABLE IF EXISTS usuarios CASCADE;
 
+DROP TYPE IF EXISTS estado_combustible CASCADE;
+DROP TYPE IF EXISTS tipo_comprobante_combustible CASCADE;
+DROP TYPE IF EXISTS estado_sesion CASCADE;
+DROP TYPE IF EXISTS resultado_auditoria CASCADE;
+DROP TYPE IF EXISTS estado_importacion CASCADE;
+DROP TYPE IF EXISTS estado_asignacion CASCADE;
+DROP TYPE IF EXISTS tipo_mantenimiento CASCADE;
+DROP TYPE IF EXISTS tipo_evento_gps CASCADE;
+DROP TYPE IF EXISTS estado_tracking CASCADE;
+DROP TYPE IF EXISTS proveedor_gps CASCADE;
 DROP TYPE IF EXISTS tipo_registro_ubicacion CASCADE;
+DROP TYPE IF EXISTS severidad_alerta CASCADE;
+DROP TYPE IF EXISTS estado_alerta_operativa CASCADE;
 DROP TYPE IF EXISTS tipo_alerta CASCADE;
 DROP TYPE IF EXISTS estado_jornada CASCADE;
+DROP TYPE IF EXISTS tipo_servicio_contrato CASCADE;
 DROP TYPE IF EXISTS estado_contrato CASCADE;
+DROP TYPE IF EXISTS tipo_combustible CASCADE;
 DROP TYPE IF EXISTS estado_unidad CASCADE;
+DROP TYPE IF EXISTS categoria_licencia CASCADE;
+DROP TYPE IF EXISTS estado_operacional_conductor CASCADE;
 DROP TYPE IF EXISTS estado_usuario CASCADE;
 DROP TYPE IF EXISTS rol_usuario CASCADE;

--- a/db/schema.mjs
+++ b/db/schema.mjs
@@ -1,314 +1,1131 @@
 export const schemaSQL = `
--- ============================================
--- 2. TIPOS ENUM
--- ============================================
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
-CREATE TYPE rol_usuario AS ENUM ('ADMIN', 'CHOFER');
-
+-- =========================================================
+-- ENUMS
+-- =========================================================
+CREATE TYPE rol_usuario AS ENUM ('ADMIN', 'CHOFER', 'GERENTE');
 CREATE TYPE estado_usuario AS ENUM ('ACTIVO', 'INACTIVO', 'BLOQUEADO');
 
-CREATE TYPE estado_unidad AS ENUM ('DISPONIBLE', 'EN_JORNADA', 'EN_AUXILIO', 'INACTIVA');
-
-CREATE TYPE estado_contrato AS ENUM ('VIGENTE', 'VENCIDO', 'SUSPENDIDO');
-
-CREATE TYPE estado_jornada AS ENUM ('REGISTRADA', 'EN_PROCESO', 'COMPLETADA', 'CANCELADA');
-
-CREATE TYPE tipo_alerta AS ENUM ('PANICO', 'AUXILIO_MECANICO');
-
-CREATE TYPE tipo_registro_ubicacion AS ENUM ('INICIO', 'FIN', 'ALERTA', 'TRACKING');
-
--- ============================================
--- 3. TABLA USUARIOS
--- Login con AWS Cognito: se guarda el perfil,
--- no la contraseña.
--- ============================================
-
-CREATE TABLE usuarios (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    cognito_sub VARCHAR(100) UNIQUE,
-    correo VARCHAR(120) NOT NULL UNIQUE,
-    nombres VARCHAR(80) NOT NULL,
-    apellidos VARCHAR(80) NOT NULL,
-    rol rol_usuario NOT NULL,
-    telefono VARCHAR(20),
-    dni VARCHAR(15) UNIQUE,
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    estado estado_usuario NOT NULL DEFAULT 'ACTIVO',
-    ultimo_acceso TIMESTAMP,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+CREATE TYPE estado_operacional_conductor AS ENUM (
+  'DISPONIBLE',
+  'EN_RUTA',
+  'DESCANSO',
+  'LICENCIA',
+  'INACTIVO'
 );
 
--- ============================================
--- 4. TABLA UNIDADES
--- ============================================
+CREATE TYPE categoria_licencia AS ENUM (
+  'A-I','A-II-a','A-II-b','A-III-a','A-III-b','A-III-c','C','D','E'
+);
+
+CREATE TYPE estado_unidad AS ENUM (
+  'DISPONIBLE',
+  'EN_JORNADA',
+  'EN_AUXILIO',
+  'MANTENIMIENTO',
+  'INACTIVA'
+);
+
+CREATE TYPE tipo_combustible AS ENUM (
+  'DIESEL',
+  'GASOLINA',
+  'GNV',
+  'GLP',
+  'ELECTRICO',
+  'HIBRIDO'
+);
+
+CREATE TYPE estado_contrato AS ENUM (
+  'VIGENTE',
+  'VENCIDO',
+  'SUSPENDIDO',
+  'INACTIVO'
+);
+
+CREATE TYPE tipo_servicio_contrato AS ENUM (
+  'POR_VIAJE',
+  'POR_HORA',
+  'POR_TONELADA',
+  'POR_KM',
+  'MENSUAL'
+);
+
+CREATE TYPE estado_jornada AS ENUM (
+  'REGISTRADA',
+  'PENDIENTE',
+  'EN_PROCESO',
+  'COMPLETADA',
+  'CANCELADA'
+);
+
+CREATE TYPE tipo_alerta AS ENUM (
+  'PANICO',
+  'AUXILIO_MECANICO',
+  'OBSERVACION'
+);
+
+CREATE TYPE estado_alerta_operativa AS ENUM (
+  'ACTIVA',
+  'EN_PROCESO',
+  'RESUELTA',
+  'FALSA_ALARMA'
+);
+
+CREATE TYPE severidad_alerta AS ENUM (
+  'BAJA',
+  'MEDIA',
+  'ALTA',
+  'CRITICA'
+);
+
+CREATE TYPE tipo_registro_ubicacion AS ENUM (
+  'INICIO',
+  'FIN',
+  'ALERTA',
+  'TRACKING',
+  'COMBUSTIBLE'
+);
+
+CREATE TYPE proveedor_gps AS ENUM (
+  'GPSCONTROL',
+  'GLOBALGPS',
+  'OTRO'
+);
+
+CREATE TYPE estado_tracking AS ENUM (
+  'MOVIENDO',
+  'DETENIDO',
+  'EXCESO_VELOCIDAD'
+);
+
+CREATE TYPE tipo_evento_gps AS ENUM (
+  'MOVIMIENTO',
+  'DETENCION',
+  'EXCESO_VELOCIDAD',
+  'FUERA_RUTA',
+  'GPS_OFFLINE'
+);
+
+CREATE TYPE tipo_mantenimiento AS ENUM (
+  'PREVENTIVO',
+  'CORRECTIVO',
+  'INSPECCION'
+);
+
+CREATE TYPE estado_asignacion AS ENUM (
+  'ACTIVA',
+  'FINALIZADA',
+  'CANCELADA'
+);
+
+CREATE TYPE estado_importacion AS ENUM (
+  'PENDIENTE',
+  'PROCESADA',
+  'PROCESADA_CON_ERRORES',
+  'RECHAZADA'
+);
+
+CREATE TYPE resultado_auditoria AS ENUM (
+  'EXITOSO',
+  'FALLIDO'
+);
+
+CREATE TYPE estado_sesion AS ENUM (
+  'ACTIVA',
+  'EXPIRADA',
+  'CERRADA',
+  'REVOCADA'
+);
+
+CREATE TYPE tipo_comprobante_combustible AS ENUM (
+  'BOLETA',
+  'FACTURA',
+  'TICKET',
+  'OTRO'
+);
+
+CREATE TYPE estado_combustible AS ENUM (
+  'BORRADOR',
+  'PENDIENTE_SINCRONIZACION',
+  'SINCRONIZADO',
+  'ANULADO'
+);
+
+-- =========================================================
+-- SEGURIDAD / USUARIOS
+-- =========================================================
+CREATE TABLE usuarios (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cognito_sub VARCHAR(100) UNIQUE,
+  correo VARCHAR(120) NOT NULL UNIQUE,
+  nombres VARCHAR(80) NOT NULL,
+  apellidos VARCHAR(80) NOT NULL,
+  rol rol_usuario NOT NULL,
+  telefono VARCHAR(20),
+  dni VARCHAR(15) UNIQUE,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  estado estado_usuario NOT NULL DEFAULT 'ACTIVO',
+  ultimo_acceso TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE login_intentos (
+  email VARCHAR(120) PRIMARY KEY,
+  intentos_fallidos INTEGER NOT NULL DEFAULT 0,
+  ultimo_intento TIMESTAMP,
+  bloqueado_hasta TIMESTAMP
+);
+
+CREATE TABLE password_reset_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  email VARCHAR(120) NOT NULL,
+  token VARCHAR(255) NOT NULL UNIQUE,
+  expira_at TIMESTAMP NOT NULL,
+  usado BOOLEAN NOT NULL DEFAULT FALSE,
+  usado_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE sesiones_usuario (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID NOT NULL REFERENCES usuarios(id) ON DELETE CASCADE,
+  access_token_jti VARCHAR(255),
+  refresh_token_jti VARCHAR(255),
+  expira_at TIMESTAMP NOT NULL,
+  ultimo_evento_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  estado estado_sesion NOT NULL DEFAULT 'ACTIVA',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE auditoria_accesos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  correo VARCHAR(120),
+  rol rol_usuario,
+  accion VARCHAR(60) NOT NULL,
+  resultado resultado_auditoria NOT NULL,
+  ip_address INET,
+  user_agent TEXT,
+  dispositivo VARCHAR(120),
+  detalle TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- CONDUCTORES
+-- =========================================================
+CREATE TABLE conductores (
+  usuario_id UUID PRIMARY KEY REFERENCES usuarios(id) ON DELETE CASCADE,
+  fecha_nacimiento DATE,
+  direccion VARCHAR(200),
+  fecha_ingreso DATE,
+  estado_operacional estado_operacional_conductor NOT NULL DEFAULT 'DISPONIBLE',
+  current_shift_id UUID,
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE contactos_emergencia (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  nombre VARCHAR(120) NOT NULL,
+  telefono VARCHAR(20) NOT NULL,
+  parentesco VARCHAR(50),
+  es_principal BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE licencias_conducir (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  numero_licencia VARCHAR(40) NOT NULL UNIQUE,
+  categoria categoria_licencia NOT NULL,
+  fecha_emision DATE,
+  fecha_vencimiento DATE NOT NULL,
+  autoridad_emisora VARCHAR(120),
+  activa BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_licencias_fechas
+    CHECK (fecha_emision IS NULL OR fecha_vencimiento >= fecha_emision)
+);
+
+CREATE TABLE conductores_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  campo VARCHAR(80),
+  valor_anterior TEXT,
+  valor_nuevo TEXT,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  ip_address INET,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- GPS / CAMIONES / UNIDADES
+-- =========================================================
+CREATE TABLE gps_dispositivos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo_equipo VARCHAR(50) NOT NULL UNIQUE,
+  proveedor proveedor_gps NOT NULL DEFAULT 'OTRO',
+  imei VARCHAR(30) UNIQUE,
+  numero_sim VARCHAR(30),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  ultima_sincronizacion TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
 
 CREATE TABLE unidades (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    placa VARCHAR(20) NOT NULL UNIQUE,
-    marca VARCHAR(50),
-    modelo VARCHAR(50),
-    anio INTEGER,
-    capacidad_ton NUMERIC(10,2),
-    estado estado_unidad NOT NULL DEFAULT 'DISPONIBLE',
-    gps_habilitado BOOLEAN NOT NULL DEFAULT TRUE,
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT chk_unidades_anio CHECK (anio IS NULL OR anio BETWEEN 1990 AND 2100),
-    CONSTRAINT chk_unidades_capacidad CHECK (capacidad_ton IS NULL OR capacidad_ton >= 0)
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  placa VARCHAR(20) NOT NULL UNIQUE,
+  marca VARCHAR(50),
+  modelo VARCHAR(50),
+  anio INTEGER,
+  capacidad_ton NUMERIC(10,2),
+  estado estado_unidad NOT NULL DEFAULT 'DISPONIBLE',
+  gps_habilitado BOOLEAN NOT NULL DEFAULT TRUE,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  vin VARCHAR(50) UNIQUE,
+  color VARCHAR(30),
+  tipo_combustible tipo_combustible,
+  fecha_registro DATE,
+  ultima_fecha_mantenimiento DATE,
+  proxima_fecha_mantenimiento DATE,
+  kilometraje_actual NUMERIC(12,2) NOT NULL DEFAULT 0,
+  gps_device_id UUID REFERENCES gps_dispositivos(id) ON DELETE SET NULL,
+  notas TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_unidades_anio CHECK (anio IS NULL OR anio BETWEEN 1990 AND 2100),
+  CONSTRAINT chk_unidades_capacidad CHECK (capacidad_ton IS NULL OR capacidad_ton >= 0),
+  CONSTRAINT chk_unidades_km CHECK (kilometraje_actual >= 0)
 );
 
--- ============================================
--- 5. TABLA CONTRATOS
--- ============================================
+-- tabla legacy para tu repo actual src/functions/camion-services/*
+CREATE TABLE camiones (
+  id BIGSERIAL PRIMARY KEY,
+  unidad_id UUID UNIQUE REFERENCES unidades(id) ON DELETE CASCADE,
+  placa VARCHAR(20) NOT NULL UNIQUE,
+  marca VARCHAR(50),
+  modelo VARCHAR(50),
+  estado VARCHAR(30) NOT NULL DEFAULT 'disponible',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
 
+CREATE TABLE camion_mantenimientos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  tipo tipo_mantenimiento NOT NULL,
+  fecha_programada DATE,
+  fecha_ejecutada DATE,
+  kilometraje NUMERIC(12,2),
+  costo NUMERIC(12,2),
+  proveedor_taller VARCHAR(150),
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE asignaciones_conductor_unidad (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  fecha_inicio TIMESTAMP NOT NULL DEFAULT NOW(),
+  fecha_fin TIMESTAMP,
+  estado estado_asignacion NOT NULL DEFAULT 'ACTIVA',
+  creado_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_asignacion_fechas CHECK (
+    fecha_fin IS NULL OR fecha_fin >= fecha_inicio
+  )
+);
+
+-- =========================================================
+-- CONTRATOS
+-- =========================================================
 CREATE TABLE contratos (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    codigo VARCHAR(30) NOT NULL UNIQUE,
-    cliente VARCHAR(120) NOT NULL,
-    descripcion TEXT,
-    fecha_inicio DATE NOT NULL,
-    fecha_fin DATE,
-    tarifa NUMERIC(12,2),
-    moneda VARCHAR(10) DEFAULT 'PEN',
-    estado estado_contrato NOT NULL DEFAULT 'VIGENTE',
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT chk_contratos_fechas CHECK (
-        fecha_fin IS NULL OR fecha_fin >= fecha_inicio
-    ),
-    CONSTRAINT chk_contratos_tarifa CHECK (
-        tarifa IS NULL OR tarifa >= 0
-    )
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) NOT NULL UNIQUE,
+  cliente VARCHAR(120) NOT NULL,
+  ruc VARCHAR(11),
+  descripcion TEXT,
+  tipo_servicio tipo_servicio_contrato NOT NULL DEFAULT 'POR_VIAJE',
+  fecha_inicio DATE NOT NULL,
+  fecha_fin DATE,
+  tarifa NUMERIC(12,2),
+  moneda VARCHAR(10) NOT NULL DEFAULT 'PEN',
+  estado estado_contrato NOT NULL DEFAULT 'VIGENTE',
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  updated_by UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_contratos_fechas CHECK (
+    fecha_fin IS NULL OR fecha_fin >= fecha_inicio
+  ),
+  CONSTRAINT chk_contratos_tarifa CHECK (
+    tarifa IS NULL OR tarifa >= 0
+  ),
+  CONSTRAINT chk_contratos_ruc CHECK (
+    ruc IS NULL OR ruc ~ '^[0-9]{11}$'
+  )
 );
 
--- ============================================
--- 6. TABLA JORNADAS
--- Tabla central del Sprint 1
--- ============================================
+CREATE TABLE contrato_rutas (
+  contrato_id UUID PRIMARY KEY REFERENCES contratos(id) ON DELETE CASCADE,
+  origen VARCHAR(150) NOT NULL,
+  destino VARCHAR(150) NOT NULL,
+  distancia_estimada_km NUMERIC(10,2) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_contrato_distancia CHECK (distancia_estimada_km >= 0)
+);
 
+CREATE TABLE contrato_tarifas (
+  contrato_id UUID PRIMARY KEY REFERENCES contratos(id) ON DELETE CASCADE,
+  tarifa_base NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_km NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_hora NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_tonelada NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_espera NUMERIC(12,2) NOT NULL DEFAULT 0,
+  total_referencial NUMERIC(12,2) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE contrato_unidades (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contrato_id UUID NOT NULL REFERENCES contratos(id) ON DELETE CASCADE,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  assigned_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  assigned_by UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE contratos_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contrato_id UUID NOT NULL REFERENCES contratos(id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  campo VARCHAR(80),
+  valor_anterior TEXT,
+  valor_nuevo TEXT,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  ip_address INET,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- JORNADAS
+-- =========================================================
 CREATE TABLE jornadas (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    conductor_id UUID NOT NULL,
-    unidad_id UUID NOT NULL,
-    contrato_id UUID NOT NULL,
-    creado_por UUID NOT NULL,
-
-    fecha_jornada DATE NOT NULL DEFAULT CURRENT_DATE,
-
-    hora_inicio TIMESTAMP NULL,
-    hora_fin TIMESTAMP NULL,
-
-    origen VARCHAR(150),
-    destino VARCHAR(150),
-    km_recorridos NUMERIC(10,2) NOT NULL DEFAULT 0,
-
-    observaciones TEXT,
-
-    estado estado_jornada NOT NULL DEFAULT 'REGISTRADA',
-
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-
-    CONSTRAINT fk_jornadas_conductor
-        FOREIGN KEY (conductor_id) REFERENCES usuarios(id),
-
-    CONSTRAINT fk_jornadas_unidad
-        FOREIGN KEY (unidad_id) REFERENCES unidades(id),
-
-    CONSTRAINT fk_jornadas_contrato
-        FOREIGN KEY (contrato_id) REFERENCES contratos(id),
-
-    CONSTRAINT fk_jornadas_creado_por
-        FOREIGN KEY (creado_por) REFERENCES usuarios(id),
-
-    CONSTRAINT chk_jornadas_horas
-        CHECK (
-            hora_fin IS NULL OR hora_inicio IS NULL OR hora_fin >= hora_inicio
-        ),
-
-    CONSTRAINT chk_jornadas_km
-        CHECK (km_recorridos >= 0)
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) UNIQUE,
+  conductor_id UUID NOT NULL REFERENCES usuarios(id),
+  unidad_id UUID NOT NULL REFERENCES unidades(id),
+  contrato_id UUID NOT NULL REFERENCES contratos(id),
+  creado_por UUID NOT NULL REFERENCES usuarios(id),
+  fecha_jornada DATE NOT NULL DEFAULT CURRENT_DATE,
+  hora_inicio_programada TIMESTAMP,
+  hora_fin_programada TIMESTAMP,
+  hora_inicio TIMESTAMP,
+  hora_fin TIMESTAMP,
+  origen VARCHAR(150),
+  destino VARCHAR(150),
+  km_estimados NUMERIC(10,2) NOT NULL DEFAULT 0,
+  km_recorridos NUMERIC(10,2) NOT NULL DEFAULT 0,
+  tipo_carga VARCHAR(120),
+  peso_carga_ton NUMERIC(10,2),
+  observaciones VARCHAR(500),
+  observacion_admin TEXT,
+  estado estado_jornada NOT NULL DEFAULT 'REGISTRADA',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_jornadas_horas CHECK (
+    hora_fin IS NULL OR hora_inicio IS NULL OR hora_fin >= hora_inicio
+  ),
+  CONSTRAINT chk_jornadas_horas_programadas CHECK (
+    hora_fin_programada IS NULL OR hora_inicio_programada IS NULL OR hora_fin_programada >= hora_inicio_programada
+  ),
+  CONSTRAINT chk_jornadas_km CHECK (
+    km_estimados >= 0 AND km_recorridos >= 0
+  ),
+  CONSTRAINT chk_jornadas_peso CHECK (
+    peso_carga_ton IS NULL OR peso_carga_ton >= 0
+  )
 );
 
--- Una unidad no puede tener dos jornadas activas
-CREATE UNIQUE INDEX uq_jornada_activa_unidad
-ON jornadas (unidad_id)
-WHERE estado IN ('REGISTRADA', 'EN_PROCESO');
+ALTER TABLE conductores
+  ADD CONSTRAINT fk_conductores_current_shift
+  FOREIGN KEY (current_shift_id) REFERENCES jornadas(id) ON DELETE SET NULL;
 
--- Un chofer no puede tener dos jornadas activas
-CREATE UNIQUE INDEX uq_jornada_activa_chofer
-ON jornadas (conductor_id)
-WHERE estado IN ('REGISTRADA', 'EN_PROCESO');
-
--- ============================================
--- 7. TABLA ALERTAS_JORNADA
--- ============================================
-
+-- =========================================================
+-- ALERTAS Y AUXILIO
+-- =========================================================
 CREATE TABLE alertas_jornada (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    jornada_id UUID NOT NULL,
-    tipo tipo_alerta NOT NULL,
-    detalle TEXT,
-    latitud NUMERIC(10,7) NOT NULL,
-    longitud NUMERIC(10,7) NOT NULL,
-    fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
-    atendida BOOLEAN NOT NULL DEFAULT FALSE,
-    atendida_por UUID NULL,
-    atendida_at TIMESTAMP NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-
-    CONSTRAINT fk_alertas_jornada
-        FOREIGN KEY (jornada_id) REFERENCES jornadas(id) ON DELETE CASCADE,
-
-    CONSTRAINT fk_alertas_atendida_por
-        FOREIGN KEY (atendida_por) REFERENCES usuarios(id),
-
-    CONSTRAINT chk_alertas_latitud
-        CHECK (latitud BETWEEN -90 AND 90),
-
-    CONSTRAINT chk_alertas_longitud
-        CHECK (longitud BETWEEN -180 AND 180),
-
-    CONSTRAINT chk_alertas_atencion
-        CHECK (
-            (atendida = FALSE)
-            OR
-            (atendida = TRUE AND atendida_at IS NOT NULL)
-        )
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) UNIQUE,
+  jornada_id UUID NOT NULL REFERENCES jornadas(id) ON DELETE CASCADE,
+  tipo tipo_alerta NOT NULL,
+  estado estado_alerta_operativa NOT NULL DEFAULT 'ACTIVA',
+  severidad severidad_alerta NOT NULL DEFAULT 'MEDIA',
+  detalle TEXT,
+  tipo_falla_mecanica VARCHAR(120),
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  direccion VARCHAR(200),
+  fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
+  atendida BOOLEAN NOT NULL DEFAULT FALSE,
+  atendida_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  atendida_at TIMESTAMP,
+  detalle_resolucion TEXT,
+  servicio_tecnico_realizado TEXT,
+  telefono_contactado VARCHAR(20),
+  bloqueo_sos_activo BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_alertas_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_alertas_longitud CHECK (longitud BETWEEN -180 AND 180),
+  CONSTRAINT chk_alertas_atencion CHECK (
+    (atendida = FALSE)
+    OR (atendida = TRUE AND atendida_at IS NOT NULL)
+  )
 );
 
--- ============================================
--- 8. TABLA UBICACIONES_JORNADA
--- ============================================
+CREATE TABLE alertas_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  alerta_id UUID NOT NULL REFERENCES alertas_jornada(id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
 
+-- =========================================================
+-- UBICACIONES / GPS
+-- =========================================================
 CREATE TABLE ubicaciones_jornada (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    jornada_id UUID NOT NULL,
-    latitud NUMERIC(10,7) NOT NULL,
-    longitud NUMERIC(10,7) NOT NULL,
-    fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
-    tipo_registro tipo_registro_ubicacion NOT NULL,
-    velocidad_kmh NUMERIC(8,2),
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-
-    CONSTRAINT fk_ubicaciones_jornada
-        FOREIGN KEY (jornada_id) REFERENCES jornadas(id) ON DELETE CASCADE,
-
-    CONSTRAINT chk_ubicaciones_latitud
-        CHECK (latitud BETWEEN -90 AND 90),
-
-    CONSTRAINT chk_ubicaciones_longitud
-        CHECK (longitud BETWEEN -180 AND 180),
-
-    CONSTRAINT chk_ubicaciones_velocidad
-        CHECK (velocidad_kmh IS NULL OR velocidad_kmh >= 0)
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  jornada_id UUID NOT NULL REFERENCES jornadas(id) ON DELETE CASCADE,
+  unidad_id UUID REFERENCES unidades(id) ON DELETE SET NULL,
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  direccion VARCHAR(200),
+  fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
+  tipo_registro tipo_registro_ubicacion NOT NULL,
+  velocidad_kmh NUMERIC(8,2),
+  rumbo NUMERIC(6,2),
+  odometro_km NUMERIC(12,2),
+  proveedor proveedor_gps,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_ubicaciones_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_ubicaciones_longitud CHECK (longitud BETWEEN -180 AND 180),
+  CONSTRAINT chk_ubicaciones_velocidad CHECK (
+    velocidad_kmh IS NULL OR velocidad_kmh >= 0
+  )
 );
 
--- ============================================
--- 9. ÍNDICES
--- ============================================
+CREATE TABLE gps_importaciones (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  proveedor proveedor_gps NOT NULL,
+  nombre_archivo VARCHAR(255) NOT NULL,
+  cargado_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  total_registros INTEGER NOT NULL DEFAULT 0,
+  registros_validos INTEGER NOT NULL DEFAULT 0,
+  registros_invalidos INTEGER NOT NULL DEFAULT 0,
+  estado estado_importacion NOT NULL DEFAULT 'PENDIENTE',
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  processed_at TIMESTAMP
+);
 
+CREATE TABLE gps_importacion_errores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  importacion_id UUID NOT NULL REFERENCES gps_importaciones(id) ON DELETE CASCADE,
+  numero_fila INTEGER NOT NULL,
+  campo VARCHAR(80),
+  valor_recibido TEXT,
+  motivo_error TEXT NOT NULL,
+  raw_payload JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE gps_proveedor_formatos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  proveedor VARCHAR(80) NOT NULL,
+  nombre_formato VARCHAR(120) NOT NULL,
+  mapeo_columnas JSONB NOT NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_gps_proveedor_formato UNIQUE (proveedor, nombre_formato)
+);
+
+CREATE TABLE gps_registros (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  importacion_id UUID REFERENCES gps_importaciones(id) ON DELETE SET NULL,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  fecha_hora TIMESTAMP NOT NULL,
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  velocidad_kmh NUMERIC(8,2),
+  rumbo NUMERIC(6,2),
+  odometro_km NUMERIC(12,2),
+  estado estado_tracking,
+  proveedor proveedor_gps NOT NULL,
+  raw_payload JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_gps_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_gps_longitud CHECK (longitud BETWEEN -180 AND 180)
+);
+
+CREATE TABLE gps_eventos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  tipo_evento tipo_evento_gps NOT NULL,
+  estado estado_tracking,
+  fecha_hora_inicio TIMESTAMP NOT NULL,
+  fecha_hora_fin TIMESTAMP,
+  velocidad_maxima NUMERIC(8,2),
+  latitud NUMERIC(10,7),
+  longitud NUMERIC(10,7),
+  distancia_km NUMERIC(10,2),
+  detalle TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_gps_evento_fechas CHECK (
+    fecha_hora_fin IS NULL OR fecha_hora_fin >= fecha_hora_inicio
+  )
+);
+
+-- =========================================================
+-- COMBUSTIBLE
+-- =========================================================
+CREATE TABLE combustible_registros (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  contrato_id UUID REFERENCES contratos(id) ON DELETE SET NULL,
+  tipo_comprobante tipo_comprobante_combustible DEFAULT 'TICKET',
+  numero_comprobante VARCHAR(50),
+  galones NUMERIC(10,2) NOT NULL,
+  costo_total NUMERIC(12,2) NOT NULL,
+  kilometraje_actual NUMERIC(12,2) NOT NULL,
+  kilometraje_anterior NUMERIC(12,2) DEFAULT 0,
+  rendimiento_km_galon NUMERIC(10,2),
+  foto_comprobante_url TEXT,
+  observaciones TEXT,
+  latitud NUMERIC(10,7),
+  longitud NUMERIC(10,7),
+  estado estado_combustible NOT NULL DEFAULT 'SINCRONIZADO',
+  sincronizado BOOLEAN NOT NULL DEFAULT TRUE,
+  registrado_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_combustible_galones CHECK (galones > 0),
+  CONSTRAINT chk_combustible_costo CHECK (costo_total >= 0),
+  CONSTRAINT chk_combustible_km CHECK (kilometraje_actual >= kilometraje_anterior)
+);
+
+-- =========================================================
+-- ÍNDICES
+-- =========================================================
 CREATE INDEX idx_usuarios_rol ON usuarios(rol);
 CREATE INDEX idx_usuarios_estado ON usuarios(estado);
 
+CREATE INDEX idx_sesiones_usuario ON sesiones_usuario(usuario_id);
+CREATE INDEX idx_sesiones_estado ON sesiones_usuario(estado);
+CREATE INDEX idx_reset_email ON password_reset_tokens(email);
+CREATE INDEX idx_auditoria_usuario ON auditoria_accesos(usuario_id);
+CREATE INDEX idx_auditoria_fecha ON auditoria_accesos(created_at);
+
+CREATE INDEX idx_conductores_estado_operacional ON conductores(estado_operacional);
+CREATE INDEX idx_contactos_emergencia_conductor ON contactos_emergencia(conductor_id);
+CREATE INDEX idx_licencias_conductor ON licencias_conducir(conductor_id);
+CREATE INDEX idx_licencias_vencimiento ON licencias_conducir(fecha_vencimiento);
+
 CREATE INDEX idx_unidades_estado ON unidades(estado);
+CREATE INDEX idx_unidades_gps_device ON unidades(gps_device_id);
+CREATE INDEX idx_camiones_unidad_id ON camiones(unidad_id);
+CREATE INDEX idx_camiones_estado ON camiones(estado);
+CREATE INDEX idx_mantenimientos_unidad ON camion_mantenimientos(unidad_id);
+
+CREATE INDEX idx_asignaciones_conductor ON asignaciones_conductor_unidad(conductor_id);
+CREATE INDEX idx_asignaciones_unidad ON asignaciones_conductor_unidad(unidad_id);
+CREATE UNIQUE INDEX uq_asignacion_activa_conductor
+  ON asignaciones_conductor_unidad(conductor_id)
+  WHERE estado = 'ACTIVA';
+CREATE UNIQUE INDEX uq_asignacion_activa_unidad
+  ON asignaciones_conductor_unidad(unidad_id)
+  WHERE estado = 'ACTIVA';
 
 CREATE INDEX idx_contratos_estado ON contratos(estado);
+CREATE INDEX idx_contratos_tipo_servicio ON contratos(tipo_servicio);
+CREATE UNIQUE INDEX uq_contrato_unidad_activa
+  ON contrato_unidades(contrato_id, unidad_id)
+  WHERE activo = TRUE;
 
 CREATE INDEX idx_jornadas_fecha ON jornadas(fecha_jornada);
 CREATE INDEX idx_jornadas_estado ON jornadas(estado);
 CREATE INDEX idx_jornadas_conductor ON jornadas(conductor_id);
 CREATE INDEX idx_jornadas_unidad ON jornadas(unidad_id);
 CREATE INDEX idx_jornadas_contrato ON jornadas(contrato_id);
+CREATE UNIQUE INDEX uq_jornada_activa_unidad
+  ON jornadas(unidad_id)
+  WHERE estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO');
+CREATE UNIQUE INDEX uq_jornada_activa_chofer
+  ON jornadas(conductor_id)
+  WHERE estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO');
 
 CREATE INDEX idx_alertas_jornada ON alertas_jornada(jornada_id);
 CREATE INDEX idx_alertas_tipo ON alertas_jornada(tipo);
+CREATE INDEX idx_alertas_estado ON alertas_jornada(estado);
 CREATE INDEX idx_alertas_fecha_hora ON alertas_jornada(fecha_hora);
+CREATE INDEX idx_alertas_historial_alerta ON alertas_historial(alerta_id);
 
 CREATE INDEX idx_ubicaciones_jornada ON ubicaciones_jornada(jornada_id);
+CREATE INDEX idx_ubicaciones_unidad ON ubicaciones_jornada(unidad_id);
 CREATE INDEX idx_ubicaciones_fecha_hora ON ubicaciones_jornada(fecha_hora);
 
--- ============================================
--- 10. TRIGGER PARA updated_at
--- ============================================
+CREATE INDEX idx_gps_importacion_errores_importacion ON gps_importacion_errores(importacion_id);
+CREATE INDEX idx_gps_registros_unidad ON gps_registros(unidad_id);
+CREATE INDEX idx_gps_registros_jornada ON gps_registros(jornada_id);
+CREATE INDEX idx_gps_registros_fecha_hora ON gps_registros(fecha_hora);
+CREATE UNIQUE INDEX uq_gps_registros_proveedor_unidad_fecha
+  ON gps_registros(proveedor, unidad_id, fecha_hora);
+CREATE INDEX idx_gps_eventos_unidad ON gps_eventos(unidad_id);
+CREATE INDEX idx_gps_eventos_jornada ON gps_eventos(jornada_id);
+CREATE INDEX idx_gps_eventos_tipo ON gps_eventos(tipo_evento);
 
+CREATE INDEX idx_combustible_unidad ON combustible_registros(unidad_id);
+CREATE INDEX idx_combustible_conductor ON combustible_registros(conductor_id);
+CREATE INDEX idx_combustible_jornada ON combustible_registros(jornada_id);
+
+-- =========================================================
+-- TRIGGER GENERICO updated_at
+-- =========================================================
 CREATE OR REPLACE FUNCTION fn_set_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.updated_at = NOW();
-    RETURN NEW;
+  NEW.updated_at = NOW();
+  RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER tg_usuarios_updated_at
 BEFORE UPDATE ON usuarios
-FOR EACH ROW
-EXECUTE FUNCTION fn_set_updated_at();
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_conductores_updated_at
+BEFORE UPDATE ON conductores
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_licencias_updated_at
+BEFORE UPDATE ON licencias_conducir
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_gps_dispositivos_updated_at
+BEFORE UPDATE ON gps_dispositivos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_gps_proveedor_formatos_updated_at
+BEFORE UPDATE ON gps_proveedor_formatos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
 
 CREATE TRIGGER tg_unidades_updated_at
 BEFORE UPDATE ON unidades
-FOR EACH ROW
-EXECUTE FUNCTION fn_set_updated_at();
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_camiones_updated_at
+BEFORE UPDATE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_mantenimientos_updated_at
+BEFORE UPDATE ON camion_mantenimientos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
 
 CREATE TRIGGER tg_contratos_updated_at
 BEFORE UPDATE ON contratos
-FOR EACH ROW
-EXECUTE FUNCTION fn_set_updated_at();
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
 
 CREATE TRIGGER tg_jornadas_updated_at
 BEFORE UPDATE ON jornadas
-FOR EACH ROW
-EXECUTE FUNCTION fn_set_updated_at();
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
 
--- ============================================
--- 11. VISTA DE SEGUIMIENTO
--- Para HU05
--- ============================================
+-- =========================================================
+-- SINCRONIZACION unidades <-> camiones
+-- =========================================================
+CREATE OR REPLACE FUNCTION fn_map_camion_estado_to_unidad(p_estado TEXT)
+RETURNS estado_unidad AS $$
+BEGIN
+  RETURN CASE LOWER(COALESCE(p_estado, 'disponible'))
+    WHEN 'disponible' THEN 'DISPONIBLE'
+    WHEN 'available' THEN 'DISPONIBLE'
+    WHEN 'activo' THEN 'DISPONIBLE'
+    WHEN 'active' THEN 'DISPONIBLE'
+    WHEN 'en_uso' THEN 'EN_JORNADA'
+    WHEN 'in_use' THEN 'EN_JORNADA'
+    WHEN 'en_jornada' THEN 'EN_JORNADA'
+    WHEN 'en_auxilio' THEN 'EN_AUXILIO'
+    WHEN 'auxilio' THEN 'EN_AUXILIO'
+    WHEN 'mantenimiento' THEN 'MANTENIMIENTO'
+    WHEN 'maintenance' THEN 'MANTENIMIENTO'
+    ELSE 'INACTIVA'
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE VIEW vw_seguimiento_jornadas AS
+CREATE OR REPLACE FUNCTION fn_map_unidad_estado_to_camion(p_estado estado_unidad)
+RETURNS TEXT AS $$
+BEGIN
+  RETURN CASE p_estado
+    WHEN 'DISPONIBLE' THEN 'disponible'
+    WHEN 'EN_JORNADA' THEN 'en_uso'
+    WHEN 'EN_AUXILIO' THEN 'en_auxilio'
+    WHEN 'MANTENIMIENTO' THEN 'maintenance'
+    ELSE 'inactivo'
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION fn_sync_unidad_to_camion()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    ELSE
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO camiones (unidad_id, placa, marca, modelo, estado, created_at, updated_at)
+    VALUES (
+      NEW.id,
+      NEW.placa,
+      NEW.marca,
+      NEW.modelo,
+      fn_map_unidad_estado_to_camion(NEW.estado),
+      NEW.created_at,
+      NEW.updated_at
+    )
+    ON CONFLICT (unidad_id) DO UPDATE
+      SET placa = EXCLUDED.placa,
+          marca = EXCLUDED.marca,
+          modelo = EXCLUDED.modelo,
+          estado = EXCLUDED.estado,
+          updated_at = NOW();
+    RETURN NEW;
+  ELSIF TG_OP = 'UPDATE' THEN
+    UPDATE camiones
+       SET placa = NEW.placa,
+           marca = NEW.marca,
+           modelo = NEW.modelo,
+           estado = fn_map_unidad_estado_to_camion(NEW.estado),
+           updated_at = NOW()
+     WHERE unidad_id = NEW.id;
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    DELETE FROM camiones WHERE unidad_id = OLD.id;
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_before_insert()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_unidad_id UUID;
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.unidad_id IS NULL THEN
+    INSERT INTO unidades (
+      placa, marca, modelo, estado, gps_habilitado, activo, created_at, updated_at
+    )
+    VALUES (
+      NEW.placa,
+      NEW.marca,
+      NEW.modelo,
+      fn_map_camion_estado_to_unidad(NEW.estado),
+      TRUE,
+      TRUE,
+      COALESCE(NEW.created_at, NOW()),
+      COALESCE(NEW.updated_at, NOW())
+    )
+    RETURNING id INTO v_unidad_id;
+
+    NEW.unidad_id := v_unidad_id;
+  END IF;
+
+  NEW.created_at := COALESCE(NEW.created_at, NOW());
+  NEW.updated_at := COALESCE(NEW.updated_at, NOW());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_after_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE unidades
+     SET placa = NEW.placa,
+         marca = NEW.marca,
+         modelo = NEW.modelo,
+         estado = fn_map_camion_estado_to_unidad(NEW.estado),
+         updated_at = NOW()
+   WHERE id = NEW.unidad_id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_after_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN OLD;
+  END IF;
+
+  DELETE FROM unidades WHERE id = OLD.unidad_id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tg_unidad_to_camion_ins
+AFTER INSERT ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_unidad_to_camion_upd
+AFTER UPDATE ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_unidad_to_camion_del
+AFTER DELETE ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_camion_before_insert
+BEFORE INSERT ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_before_insert();
+
+CREATE TRIGGER tg_camion_after_update
+AFTER UPDATE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_after_update();
+
+CREATE TRIGGER tg_camion_after_delete
+AFTER DELETE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_after_delete();
+
+-- =========================================================
+-- VISTAS
+-- =========================================================
+CREATE OR REPLACE VIEW vw_conductores_full AS
 SELECT
-    j.id,
-    j.fecha_jornada,
-    CONCAT(u.nombres, ' ', u.apellidos) AS nombre_chofer,
-    un.placa AS placa_camion,
-    c.codigo AS codigo_contrato,
-    c.cliente,
-    j.origen,
-    j.destino,
-    j.hora_inicio,
-    j.hora_fin,
-    CASE
-        WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
-            THEN (j.hora_fin - j.hora_inicio)
-        ELSE NULL
-    END AS duracion_total,
-    j.km_recorridos,
-    j.estado,
-    j.observaciones,
-    EXISTS (
-        SELECT 1
-        FROM alertas_jornada a
-        WHERE a.jornada_id = j.id
-          AND a.tipo = 'PANICO'
-    ) AS tiene_panico,
-    EXISTS (
-        SELECT 1
-        FROM alertas_jornada a
-        WHERE a.jornada_id = j.id
-          AND a.tipo = 'AUXILIO_MECANICO'
-    ) AS tiene_auxilio,
-    (
-        SELECT COUNT(*)
-        FROM alertas_jornada a
-        WHERE a.jornada_id = j.id
-    ) AS total_alertas
+  u.id AS usuario_id,
+  u.cognito_sub,
+  u.correo,
+  u.nombres,
+  u.apellidos,
+  CONCAT(u.nombres, ' ', u.apellidos) AS nombre_completo,
+  u.telefono,
+  u.dni,
+  u.rol,
+  u.estado AS estado_usuario,
+  c.fecha_nacimiento,
+  c.direccion,
+  c.fecha_ingreso,
+  c.estado_operacional,
+  c.current_shift_id,
+  lc.numero_licencia,
+  lc.categoria AS licencia_categoria,
+  lc.fecha_vencimiento AS licencia_vencimiento,
+  ce.nombre AS contacto_emergencia_nombre,
+  ce.telefono AS contacto_emergencia_telefono,
+  ce.parentesco AS contacto_emergencia_parentesco,
+  a.unidad_id AS unidad_asignada_id,
+  un.placa AS placa_asignada
+FROM usuarios u
+JOIN conductores c ON c.usuario_id = u.id
+LEFT JOIN LATERAL (
+  SELECT l.*
+  FROM licencias_conducir l
+  WHERE l.conductor_id = c.usuario_id AND l.activa = TRUE
+  ORDER BY l.fecha_vencimiento DESC
+  LIMIT 1
+) lc ON TRUE
+LEFT JOIN LATERAL (
+  SELECT x.*
+  FROM contactos_emergencia x
+  WHERE x.conductor_id = c.usuario_id AND x.es_principal = TRUE
+  ORDER BY x.created_at DESC
+  LIMIT 1
+) ce ON TRUE
+LEFT JOIN LATERAL (
+  SELECT ac.*
+  FROM asignaciones_conductor_unidad ac
+  WHERE ac.conductor_id = c.usuario_id AND ac.estado = 'ACTIVA'
+  ORDER BY ac.fecha_inicio DESC
+  LIMIT 1
+) a ON TRUE
+LEFT JOIN unidades un ON un.id = a.unidad_id
+WHERE u.rol = 'CHOFER';
+
+CREATE OR REPLACE VIEW vw_camiones_operativos AS
+SELECT
+  un.id AS unidad_id,
+  c.id AS camion_legacy_id,
+  un.placa,
+  un.marca,
+  un.modelo,
+  un.anio,
+  un.capacidad_ton,
+  un.estado,
+  un.activo,
+  un.vin,
+  un.color,
+  un.tipo_combustible,
+  un.kilometraje_actual,
+  un.gps_habilitado,
+  gd.codigo_equipo AS gps_codigo_equipo,
+  gd.proveedor AS gps_proveedor,
+  un.ultima_fecha_mantenimiento,
+  un.proxima_fecha_mantenimiento
+FROM unidades un
+LEFT JOIN camiones c ON c.unidad_id = un.id
+LEFT JOIN gps_dispositivos gd ON gd.id = un.gps_device_id;
+
+CREATE OR REPLACE VIEW vw_historial_jornadas_chofer AS
+SELECT
+  j.id,
+  j.codigo,
+  j.conductor_id,
+  j.fecha_jornada,
+  j.origen,
+  j.destino,
+  j.hora_inicio,
+  j.hora_fin,
+  CASE
+    WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
+    THEN (j.hora_fin - j.hora_inicio)
+    ELSE NULL
+  END AS duracion_total,
+  j.km_recorridos,
+  j.observaciones,
+  j.estado,
+  j.unidad_id,
+  un.placa
 FROM jornadas j
-INNER JOIN usuarios u ON u.id = j.conductor_id
-INNER JOIN unidades un ON un.id = j.unidad_id
-INNER JOIN contratos c ON c.id = j.contrato_id
+JOIN unidades un ON un.id = j.unidad_id
+WHERE j.estado = 'COMPLETADA';
+
+CREATE OR REPLACE VIEW vw_seguimiento_jornadas AS
+SELECT
+  j.id,
+  j.codigo,
+  j.fecha_jornada,
+  j.conductor_id,
+  CONCAT(u.nombres, ' ', u.apellidos) AS nombre_chofer,
+  j.unidad_id,
+  un.placa AS placa_camion,
+  un.marca,
+  un.modelo,
+  j.contrato_id,
+  c.codigo AS codigo_contrato,
+  c.cliente,
+  j.origen,
+  j.destino,
+  j.hora_inicio,
+  j.hora_fin,
+  CASE
+    WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
+    THEN (j.hora_fin - j.hora_inicio)
+    ELSE NULL
+  END AS duracion_total,
+  j.km_estimados,
+  j.km_recorridos,
+  j.estado,
+  j.observaciones,
+  EXISTS (
+    SELECT 1 FROM alertas_jornada a
+    WHERE a.jornada_id = j.id AND a.tipo = 'PANICO'
+  ) AS tiene_panico,
+  EXISTS (
+    SELECT 1 FROM alertas_jornada a
+    WHERE a.jornada_id = j.id AND a.tipo = 'AUXILIO_MECANICO'
+  ) AS tiene_auxilio,
+  (SELECT COUNT(*) FROM alertas_jornada a WHERE a.jornada_id = j.id) AS total_alertas
+FROM jornadas j
+JOIN usuarios u ON u.id = j.conductor_id
+JOIN unidades un ON un.id = j.unidad_id
+JOIN contratos c ON c.id = j.contrato_id
 ORDER BY j.fecha_jornada DESC, j.created_at DESC;
 
+CREATE OR REPLACE VIEW vw_tracking_gps AS
+SELECT
+  gr.id,
+  gr.unidad_id,
+  un.placa,
+  gr.jornada_id,
+  gr.fecha_hora,
+  gr.latitud,
+  gr.longitud,
+  gr.rumbo,
+  gr.velocidad_kmh,
+  gr.estado,
+  gr.odometro_km,
+  gr.proveedor
+FROM gps_registros gr
+JOIN unidades un ON un.id = gr.unidad_id;
+
+CREATE OR REPLACE VIEW vw_alertas_panel AS
+SELECT
+  a.id,
+  a.codigo,
+  a.jornada_id,
+  a.tipo,
+  a.estado,
+  a.severidad,
+  a.detalle,
+  a.tipo_falla_mecanica,
+  a.latitud,
+  a.longitud,
+  a.direccion,
+  a.fecha_hora,
+  a.atendida,
+  a.atendida_at,
+  j.unidad_id,
+  un.placa,
+  CONCAT(u.nombres, ' ', u.apellidos) AS conductor
+FROM alertas_jornada a
+JOIN jornadas j ON j.id = a.jornada_id
+JOIN unidades un ON un.id = j.unidad_id
+JOIN usuarios u ON u.id = j.conductor_id
+ORDER BY a.fecha_hora DESC;
+
+CREATE OR REPLACE VIEW vw_dashboard_resumen AS
+SELECT
+  (SELECT COUNT(*) FROM unidades WHERE activo = TRUE) AS total_camiones,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'EN_JORNADA') AS camiones_en_uso,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'DISPONIBLE') AS camiones_disponibles,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'MANTENIMIENTO') AS camiones_mantenimiento,
+  (SELECT COUNT(*) FROM usuarios WHERE rol = 'CHOFER' AND activo = TRUE) AS total_conductores,
+  (SELECT COUNT(*) FROM conductores WHERE estado_operacional = 'EN_RUTA') AS conductores_en_ruta,
+  (SELECT COUNT(*) FROM contratos WHERE estado = 'VIGENTE' AND activo = TRUE) AS contratos_activos,
+  (SELECT COUNT(*) FROM jornadas WHERE estado IN ('REGISTRADA','PENDIENTE','EN_PROCESO')) AS jornadas_activas,
+  (SELECT COUNT(*) FROM alertas_jornada WHERE estado IN ('ACTIVA','EN_PROCESO')) AS alertas_activas,
+  (SELECT COALESCE(SUM(km_recorridos), 0) FROM jornadas WHERE estado = 'COMPLETADA') AS km_totales_operados;
 `;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,164 +1,1129 @@
--- ============================================
--- NANUTECH - SCHEMA PARA TESTS (pg-mem)
--- SIN triggers, SIN funciones, SIN vistas
--- ============================================
-
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
--- ============================================
--- TIPOS ENUM
--- ============================================
-
-CREATE TYPE rol_usuario AS ENUM ('ADMIN', 'CHOFER');
+-- =========================================================
+-- ENUMS
+-- =========================================================
+CREATE TYPE rol_usuario AS ENUM ('ADMIN', 'CHOFER', 'GERENTE');
 CREATE TYPE estado_usuario AS ENUM ('ACTIVO', 'INACTIVO', 'BLOQUEADO');
-CREATE TYPE estado_unidad AS ENUM ('DISPONIBLE', 'EN_JORNADA', 'EN_AUXILIO', 'INACTIVA');
-CREATE TYPE estado_contrato AS ENUM ('VIGENTE', 'VENCIDO', 'SUSPENDIDO');
-CREATE TYPE estado_jornada AS ENUM ('REGISTRADA', 'EN_PROCESO', 'COMPLETADA', 'CANCELADA');
-CREATE TYPE tipo_alerta AS ENUM ('PANICO', 'AUXILIO_MECANICO');
-CREATE TYPE tipo_registro_ubicacion AS ENUM ('INICIO', 'FIN', 'ALERTA', 'TRACKING');
 
--- ============================================
--- TABLA USUARIOS
--- ============================================
-
-CREATE TABLE usuarios (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    cognito_sub VARCHAR(100) UNIQUE,
-    correo VARCHAR(120) NOT NULL UNIQUE,
-    nombres VARCHAR(80) NOT NULL,
-    apellidos VARCHAR(80) NOT NULL,
-    rol rol_usuario NOT NULL,
-    telefono VARCHAR(20),
-    dni VARCHAR(15) UNIQUE,
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    estado estado_usuario NOT NULL DEFAULT 'ACTIVO',
-    ultimo_acceso TIMESTAMP,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+CREATE TYPE estado_operacional_conductor AS ENUM (
+  'DISPONIBLE',
+  'EN_RUTA',
+  'DESCANSO',
+  'LICENCIA',
+  'INACTIVO'
 );
 
--- ============================================
--- TABLA UNIDADES
--- ============================================
+CREATE TYPE categoria_licencia AS ENUM (
+  'A-I','A-II-a','A-II-b','A-III-a','A-III-b','A-III-c','C','D','E'
+);
+
+CREATE TYPE estado_unidad AS ENUM (
+  'DISPONIBLE',
+  'EN_JORNADA',
+  'EN_AUXILIO',
+  'MANTENIMIENTO',
+  'INACTIVA'
+);
+
+CREATE TYPE tipo_combustible AS ENUM (
+  'DIESEL',
+  'GASOLINA',
+  'GNV',
+  'GLP',
+  'ELECTRICO',
+  'HIBRIDO'
+);
+
+CREATE TYPE estado_contrato AS ENUM (
+  'VIGENTE',
+  'VENCIDO',
+  'SUSPENDIDO',
+  'INACTIVO'
+);
+
+CREATE TYPE tipo_servicio_contrato AS ENUM (
+  'POR_VIAJE',
+  'POR_HORA',
+  'POR_TONELADA',
+  'POR_KM',
+  'MENSUAL'
+);
+
+CREATE TYPE estado_jornada AS ENUM (
+  'REGISTRADA',
+  'PENDIENTE',
+  'EN_PROCESO',
+  'COMPLETADA',
+  'CANCELADA'
+);
+
+CREATE TYPE tipo_alerta AS ENUM (
+  'PANICO',
+  'AUXILIO_MECANICO',
+  'OBSERVACION'
+);
+
+CREATE TYPE estado_alerta_operativa AS ENUM (
+  'ACTIVA',
+  'EN_PROCESO',
+  'RESUELTA',
+  'FALSA_ALARMA'
+);
+
+CREATE TYPE severidad_alerta AS ENUM (
+  'BAJA',
+  'MEDIA',
+  'ALTA',
+  'CRITICA'
+);
+
+CREATE TYPE tipo_registro_ubicacion AS ENUM (
+  'INICIO',
+  'FIN',
+  'ALERTA',
+  'TRACKING',
+  'COMBUSTIBLE'
+);
+
+CREATE TYPE proveedor_gps AS ENUM (
+  'GPSCONTROL',
+  'GLOBALGPS',
+  'OTRO'
+);
+
+CREATE TYPE estado_tracking AS ENUM (
+  'MOVIENDO',
+  'DETENIDO',
+  'EXCESO_VELOCIDAD'
+);
+
+CREATE TYPE tipo_evento_gps AS ENUM (
+  'MOVIMIENTO',
+  'DETENCION',
+  'EXCESO_VELOCIDAD',
+  'FUERA_RUTA',
+  'GPS_OFFLINE'
+);
+
+CREATE TYPE tipo_mantenimiento AS ENUM (
+  'PREVENTIVO',
+  'CORRECTIVO',
+  'INSPECCION'
+);
+
+CREATE TYPE estado_asignacion AS ENUM (
+  'ACTIVA',
+  'FINALIZADA',
+  'CANCELADA'
+);
+
+CREATE TYPE estado_importacion AS ENUM (
+  'PENDIENTE',
+  'PROCESADA',
+  'PROCESADA_CON_ERRORES',
+  'RECHAZADA'
+);
+
+CREATE TYPE resultado_auditoria AS ENUM (
+  'EXITOSO',
+  'FALLIDO'
+);
+
+CREATE TYPE estado_sesion AS ENUM (
+  'ACTIVA',
+  'EXPIRADA',
+  'CERRADA',
+  'REVOCADA'
+);
+
+CREATE TYPE tipo_comprobante_combustible AS ENUM (
+  'BOLETA',
+  'FACTURA',
+  'TICKET',
+  'OTRO'
+);
+
+CREATE TYPE estado_combustible AS ENUM (
+  'BORRADOR',
+  'PENDIENTE_SINCRONIZACION',
+  'SINCRONIZADO',
+  'ANULADO'
+);
+
+-- =========================================================
+-- SEGURIDAD / USUARIOS
+-- =========================================================
+CREATE TABLE usuarios (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cognito_sub VARCHAR(100) UNIQUE,
+  correo VARCHAR(120) NOT NULL UNIQUE,
+  nombres VARCHAR(80) NOT NULL,
+  apellidos VARCHAR(80) NOT NULL,
+  rol rol_usuario NOT NULL,
+  telefono VARCHAR(20),
+  dni VARCHAR(15) UNIQUE,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  estado estado_usuario NOT NULL DEFAULT 'ACTIVO',
+  ultimo_acceso TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE login_intentos (
+  email VARCHAR(120) PRIMARY KEY,
+  intentos_fallidos INTEGER NOT NULL DEFAULT 0,
+  ultimo_intento TIMESTAMP,
+  bloqueado_hasta TIMESTAMP
+);
+
+CREATE TABLE password_reset_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  email VARCHAR(120) NOT NULL,
+  token VARCHAR(255) NOT NULL UNIQUE,
+  expira_at TIMESTAMP NOT NULL,
+  usado BOOLEAN NOT NULL DEFAULT FALSE,
+  usado_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE sesiones_usuario (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID NOT NULL REFERENCES usuarios(id) ON DELETE CASCADE,
+  access_token_jti VARCHAR(255),
+  refresh_token_jti VARCHAR(255),
+  expira_at TIMESTAMP NOT NULL,
+  ultimo_evento_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  estado estado_sesion NOT NULL DEFAULT 'ACTIVA',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE auditoria_accesos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  correo VARCHAR(120),
+  rol rol_usuario,
+  accion VARCHAR(60) NOT NULL,
+  resultado resultado_auditoria NOT NULL,
+  ip_address INET,
+  user_agent TEXT,
+  dispositivo VARCHAR(120),
+  detalle TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- CONDUCTORES
+-- =========================================================
+CREATE TABLE conductores (
+  usuario_id UUID PRIMARY KEY REFERENCES usuarios(id) ON DELETE CASCADE,
+  fecha_nacimiento DATE,
+  direccion VARCHAR(200),
+  fecha_ingreso DATE,
+  estado_operacional estado_operacional_conductor NOT NULL DEFAULT 'DISPONIBLE',
+  current_shift_id UUID,
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE contactos_emergencia (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  nombre VARCHAR(120) NOT NULL,
+  telefono VARCHAR(20) NOT NULL,
+  parentesco VARCHAR(50),
+  es_principal BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE licencias_conducir (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  numero_licencia VARCHAR(40) NOT NULL UNIQUE,
+  categoria categoria_licencia NOT NULL,
+  fecha_emision DATE,
+  fecha_vencimiento DATE NOT NULL,
+  autoridad_emisora VARCHAR(120),
+  activa BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_licencias_fechas
+    CHECK (fecha_emision IS NULL OR fecha_vencimiento >= fecha_emision)
+);
+
+CREATE TABLE conductores_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  campo VARCHAR(80),
+  valor_anterior TEXT,
+  valor_nuevo TEXT,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  ip_address INET,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- GPS / CAMIONES / UNIDADES
+-- =========================================================
+CREATE TABLE gps_dispositivos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo_equipo VARCHAR(50) NOT NULL UNIQUE,
+  proveedor proveedor_gps NOT NULL DEFAULT 'OTRO',
+  imei VARCHAR(30) UNIQUE,
+  numero_sim VARCHAR(30),
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  ultima_sincronizacion TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
 
 CREATE TABLE unidades (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    placa VARCHAR(20) NOT NULL UNIQUE,
-    marca VARCHAR(50),
-    modelo VARCHAR(50),
-    anio INTEGER,
-    capacidad_ton NUMERIC(10,2),
-    estado estado_unidad NOT NULL DEFAULT 'DISPONIBLE',
-    gps_habilitado BOOLEAN NOT NULL DEFAULT TRUE,
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  placa VARCHAR(20) NOT NULL UNIQUE,
+  marca VARCHAR(50),
+  modelo VARCHAR(50),
+  anio INTEGER,
+  capacidad_ton NUMERIC(10,2),
+  estado estado_unidad NOT NULL DEFAULT 'DISPONIBLE',
+  gps_habilitado BOOLEAN NOT NULL DEFAULT TRUE,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  vin VARCHAR(50) UNIQUE,
+  color VARCHAR(30),
+  tipo_combustible tipo_combustible,
+  fecha_registro DATE,
+  ultima_fecha_mantenimiento DATE,
+  proxima_fecha_mantenimiento DATE,
+  kilometraje_actual NUMERIC(12,2) NOT NULL DEFAULT 0,
+  gps_device_id UUID REFERENCES gps_dispositivos(id) ON DELETE SET NULL,
+  notas TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_unidades_anio CHECK (anio IS NULL OR anio BETWEEN 1990 AND 2100),
+  CONSTRAINT chk_unidades_capacidad CHECK (capacidad_ton IS NULL OR capacidad_ton >= 0),
+  CONSTRAINT chk_unidades_km CHECK (kilometraje_actual >= 0)
 );
 
--- ============================================
--- TABLA CONTRATOS
--- ============================================
-
-CREATE TABLE contratos (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    codigo VARCHAR(30) NOT NULL UNIQUE,
-    cliente VARCHAR(120) NOT NULL,
-    descripcion TEXT,
-    fecha_inicio DATE NOT NULL,
-    fecha_fin DATE,
-    tarifa NUMERIC(12,2),
-    moneda VARCHAR(10) DEFAULT 'PEN',
-    estado estado_contrato NOT NULL DEFAULT 'VIGENTE',
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
-);
-
--- ============================================
--- TABLA JORNADAS
--- ============================================
-
-CREATE TABLE jornadas (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    conductor_id UUID NOT NULL,
-    unidad_id UUID NOT NULL,
-    contrato_id UUID NOT NULL,
-    creado_por UUID NOT NULL,
-    fecha_jornada DATE NOT NULL DEFAULT CURRENT_DATE,
-    hora_inicio TIMESTAMP NULL,
-    hora_fin TIMESTAMP NULL,
-    origen VARCHAR(150),
-    destino VARCHAR(150),
-    km_recorridos NUMERIC(10,2) NOT NULL DEFAULT 0,
-    observaciones TEXT,
-    estado estado_jornada NOT NULL DEFAULT 'REGISTRADA',
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-
-    CONSTRAINT fk_jornadas_conductor
-        FOREIGN KEY (conductor_id) REFERENCES usuarios(id),
-    CONSTRAINT fk_jornadas_unidad
-        FOREIGN KEY (unidad_id) REFERENCES unidades(id),
-    CONSTRAINT fk_jornadas_contrato
-        FOREIGN KEY (contrato_id) REFERENCES contratos(id),
-    CONSTRAINT fk_jornadas_creado_por
-        FOREIGN KEY (creado_por) REFERENCES usuarios(id)
-);
-
--- ============================================
--- TABLA ALERTAS_JORNADA
--- ============================================
-
-CREATE TABLE alertas_jornada (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    jornada_id UUID NOT NULL,
-    tipo tipo_alerta NOT NULL,
-    detalle TEXT,
-    latitud NUMERIC(10,7) NOT NULL,
-    longitud NUMERIC(10,7) NOT NULL,
-    fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
-    atendida BOOLEAN NOT NULL DEFAULT FALSE,
-    atendida_por UUID NULL,
-    atendida_at TIMESTAMP NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-
-    CONSTRAINT fk_alertas_jornada
-        FOREIGN KEY (jornada_id) REFERENCES jornadas(id) ON DELETE CASCADE
-);
-
--- ============================================
--- TABLA UBICACIONES_JORNADA
--- ============================================
-
-CREATE TABLE ubicaciones_jornada (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    jornada_id UUID NOT NULL,
-    latitud NUMERIC(10,7) NOT NULL,
-    longitud NUMERIC(10,7) NOT NULL,
-    fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
-    tipo_registro tipo_registro_ubicacion NOT NULL,
-    velocidad_kmh NUMERIC(8,2),
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-
-    CONSTRAINT fk_ubicaciones_jornada
-        FOREIGN KEY (jornada_id) REFERENCES jornadas(id) ON DELETE CASCADE
-);
-
-
--- Cambiar el nombre de la tabla
+-- tabla legacy para tu repo actual src/functions/camion-services/*
 CREATE TABLE camiones (
-    id INTEGER PRIMARY KEY ,
-    placa VARCHAR(20) NOT NULL UNIQUE,
-    marca VARCHAR(50),
-    modelo VARCHAR(50),
-    anio INTEGER,
-    capacidad_ton NUMERIC(10,2),
-    estado estado_unidad NOT NULL DEFAULT 'DISPONIBLE',
-    gps_habilitado BOOLEAN NOT NULL DEFAULT TRUE,
-    activo BOOLEAN NOT NULL DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+  id BIGSERIAL PRIMARY KEY,
+  unidad_id UUID UNIQUE REFERENCES unidades(id) ON DELETE CASCADE,
+  placa VARCHAR(20) NOT NULL UNIQUE,
+  marca VARCHAR(50),
+  modelo VARCHAR(50),
+  estado VARCHAR(30) NOT NULL DEFAULT 'disponible',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
--- También actualizar las referencias en otras tablas
--- En jornadas, cambiar unidad_id a camion_id si es necesario
+CREATE TABLE camion_mantenimientos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  tipo tipo_mantenimiento NOT NULL,
+  fecha_programada DATE,
+  fecha_ejecutada DATE,
+  kilometraje NUMERIC(12,2),
+  costo NUMERIC(12,2),
+  proveedor_taller VARCHAR(150),
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE asignaciones_conductor_unidad (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  fecha_inicio TIMESTAMP NOT NULL DEFAULT NOW(),
+  fecha_fin TIMESTAMP,
+  estado estado_asignacion NOT NULL DEFAULT 'ACTIVA',
+  creado_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_asignacion_fechas CHECK (
+    fecha_fin IS NULL OR fecha_fin >= fecha_inicio
+  )
+);
+
+-- =========================================================
+-- CONTRATOS
+-- =========================================================
+CREATE TABLE contratos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) NOT NULL UNIQUE,
+  cliente VARCHAR(120) NOT NULL,
+  ruc VARCHAR(11),
+  descripcion TEXT,
+  tipo_servicio tipo_servicio_contrato NOT NULL DEFAULT 'POR_VIAJE',
+  fecha_inicio DATE NOT NULL,
+  fecha_fin DATE,
+  tarifa NUMERIC(12,2),
+  moneda VARCHAR(10) NOT NULL DEFAULT 'PEN',
+  estado estado_contrato NOT NULL DEFAULT 'VIGENTE',
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  updated_by UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_contratos_fechas CHECK (
+    fecha_fin IS NULL OR fecha_fin >= fecha_inicio
+  ),
+  CONSTRAINT chk_contratos_tarifa CHECK (
+    tarifa IS NULL OR tarifa >= 0
+  ),
+  CONSTRAINT chk_contratos_ruc CHECK (
+    ruc IS NULL OR ruc ~ '^[0-9]{11}$'
+  )
+);
+
+CREATE TABLE contrato_rutas (
+  contrato_id UUID PRIMARY KEY REFERENCES contratos(id) ON DELETE CASCADE,
+  origen VARCHAR(150) NOT NULL,
+  destino VARCHAR(150) NOT NULL,
+  distancia_estimada_km NUMERIC(10,2) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_contrato_distancia CHECK (distancia_estimada_km >= 0)
+);
+
+CREATE TABLE contrato_tarifas (
+  contrato_id UUID PRIMARY KEY REFERENCES contratos(id) ON DELETE CASCADE,
+  tarifa_base NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_km NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_hora NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_por_tonelada NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tarifa_espera NUMERIC(12,2) NOT NULL DEFAULT 0,
+  total_referencial NUMERIC(12,2) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE contrato_unidades (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contrato_id UUID NOT NULL REFERENCES contratos(id) ON DELETE CASCADE,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  assigned_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  assigned_by UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE contratos_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contrato_id UUID NOT NULL REFERENCES contratos(id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  campo VARCHAR(80),
+  valor_anterior TEXT,
+  valor_nuevo TEXT,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  ip_address INET,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- JORNADAS
+-- =========================================================
+CREATE TABLE jornadas (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) UNIQUE,
+  conductor_id UUID NOT NULL REFERENCES usuarios(id),
+  unidad_id UUID NOT NULL REFERENCES unidades(id),
+  contrato_id UUID NOT NULL REFERENCES contratos(id),
+  creado_por UUID NOT NULL REFERENCES usuarios(id),
+  fecha_jornada DATE NOT NULL DEFAULT CURRENT_DATE,
+  hora_inicio_programada TIMESTAMP,
+  hora_fin_programada TIMESTAMP,
+  hora_inicio TIMESTAMP,
+  hora_fin TIMESTAMP,
+  origen VARCHAR(150),
+  destino VARCHAR(150),
+  km_estimados NUMERIC(10,2) NOT NULL DEFAULT 0,
+  km_recorridos NUMERIC(10,2) NOT NULL DEFAULT 0,
+  tipo_carga VARCHAR(120),
+  peso_carga_ton NUMERIC(10,2),
+  observaciones VARCHAR(500),
+  observacion_admin TEXT,
+  estado estado_jornada NOT NULL DEFAULT 'REGISTRADA',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_jornadas_horas CHECK (
+    hora_fin IS NULL OR hora_inicio IS NULL OR hora_fin >= hora_inicio
+  ),
+  CONSTRAINT chk_jornadas_horas_programadas CHECK (
+    hora_fin_programada IS NULL OR hora_inicio_programada IS NULL OR hora_fin_programada >= hora_inicio_programada
+  ),
+  CONSTRAINT chk_jornadas_km CHECK (
+    km_estimados >= 0 AND km_recorridos >= 0
+  ),
+  CONSTRAINT chk_jornadas_peso CHECK (
+    peso_carga_ton IS NULL OR peso_carga_ton >= 0
+  )
+);
+
+ALTER TABLE conductores
+  ADD CONSTRAINT fk_conductores_current_shift
+  FOREIGN KEY (current_shift_id) REFERENCES jornadas(id) ON DELETE SET NULL;
+
+-- =========================================================
+-- ALERTAS Y AUXILIO
+-- =========================================================
+CREATE TABLE alertas_jornada (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo VARCHAR(30) UNIQUE,
+  jornada_id UUID NOT NULL REFERENCES jornadas(id) ON DELETE CASCADE,
+  tipo tipo_alerta NOT NULL,
+  estado estado_alerta_operativa NOT NULL DEFAULT 'ACTIVA',
+  severidad severidad_alerta NOT NULL DEFAULT 'MEDIA',
+  detalle TEXT,
+  tipo_falla_mecanica VARCHAR(120),
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  direccion VARCHAR(200),
+  fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
+  atendida BOOLEAN NOT NULL DEFAULT FALSE,
+  atendida_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  atendida_at TIMESTAMP,
+  detalle_resolucion TEXT,
+  servicio_tecnico_realizado TEXT,
+  telefono_contactado VARCHAR(20),
+  bloqueo_sos_activo BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_alertas_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_alertas_longitud CHECK (longitud BETWEEN -180 AND 180),
+  CONSTRAINT chk_alertas_atencion CHECK (
+    (atendida = FALSE)
+    OR (atendida = TRUE AND atendida_at IS NOT NULL)
+  )
+);
+
+CREATE TABLE alertas_historial (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  alerta_id UUID NOT NULL REFERENCES alertas_jornada(id) ON DELETE CASCADE,
+  accion VARCHAR(120) NOT NULL,
+  detalle TEXT,
+  usuario_id UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- =========================================================
+-- UBICACIONES / GPS
+-- =========================================================
+CREATE TABLE ubicaciones_jornada (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  jornada_id UUID NOT NULL REFERENCES jornadas(id) ON DELETE CASCADE,
+  unidad_id UUID REFERENCES unidades(id) ON DELETE SET NULL,
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  direccion VARCHAR(200),
+  fecha_hora TIMESTAMP NOT NULL DEFAULT NOW(),
+  tipo_registro tipo_registro_ubicacion NOT NULL,
+  velocidad_kmh NUMERIC(8,2),
+  rumbo NUMERIC(6,2),
+  odometro_km NUMERIC(12,2),
+  proveedor proveedor_gps,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_ubicaciones_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_ubicaciones_longitud CHECK (longitud BETWEEN -180 AND 180),
+  CONSTRAINT chk_ubicaciones_velocidad CHECK (
+    velocidad_kmh IS NULL OR velocidad_kmh >= 0
+  )
+);
+
+CREATE TABLE gps_importaciones (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  proveedor proveedor_gps NOT NULL,
+  nombre_archivo VARCHAR(255) NOT NULL,
+  cargado_por UUID REFERENCES usuarios(id) ON DELETE SET NULL,
+  total_registros INTEGER NOT NULL DEFAULT 0,
+  registros_validos INTEGER NOT NULL DEFAULT 0,
+  registros_invalidos INTEGER NOT NULL DEFAULT 0,
+  estado estado_importacion NOT NULL DEFAULT 'PENDIENTE',
+  observaciones TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  processed_at TIMESTAMP
+);
+
+CREATE TABLE gps_importacion_errores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  importacion_id UUID NOT NULL REFERENCES gps_importaciones(id) ON DELETE CASCADE,
+  numero_fila INTEGER NOT NULL,
+  campo VARCHAR(80),
+  valor_recibido TEXT,
+  motivo_error TEXT NOT NULL,
+  raw_payload JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE gps_proveedor_formatos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  proveedor VARCHAR(80) NOT NULL,
+  nombre_formato VARCHAR(120) NOT NULL,
+  mapeo_columnas JSONB NOT NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_gps_proveedor_formato UNIQUE (proveedor, nombre_formato)
+);
+
+CREATE TABLE gps_registros (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  importacion_id UUID REFERENCES gps_importaciones(id) ON DELETE SET NULL,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  fecha_hora TIMESTAMP NOT NULL,
+  latitud NUMERIC(10,7) NOT NULL,
+  longitud NUMERIC(10,7) NOT NULL,
+  velocidad_kmh NUMERIC(8,2),
+  rumbo NUMERIC(6,2),
+  odometro_km NUMERIC(12,2),
+  estado estado_tracking,
+  proveedor proveedor_gps NOT NULL,
+  raw_payload JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_gps_latitud CHECK (latitud BETWEEN -90 AND 90),
+  CONSTRAINT chk_gps_longitud CHECK (longitud BETWEEN -180 AND 180)
+);
+
+CREATE TABLE gps_eventos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  tipo_evento tipo_evento_gps NOT NULL,
+  estado estado_tracking,
+  fecha_hora_inicio TIMESTAMP NOT NULL,
+  fecha_hora_fin TIMESTAMP,
+  velocidad_maxima NUMERIC(8,2),
+  latitud NUMERIC(10,7),
+  longitud NUMERIC(10,7),
+  distancia_km NUMERIC(10,2),
+  detalle TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_gps_evento_fechas CHECK (
+    fecha_hora_fin IS NULL OR fecha_hora_fin >= fecha_hora_inicio
+  )
+);
+
+-- =========================================================
+-- COMBUSTIBLE
+-- =========================================================
+CREATE TABLE combustible_registros (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  jornada_id UUID REFERENCES jornadas(id) ON DELETE SET NULL,
+  unidad_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE,
+  conductor_id UUID NOT NULL REFERENCES conductores(usuario_id) ON DELETE CASCADE,
+  contrato_id UUID REFERENCES contratos(id) ON DELETE SET NULL,
+  tipo_comprobante tipo_comprobante_combustible DEFAULT 'TICKET',
+  numero_comprobante VARCHAR(50),
+  galones NUMERIC(10,2) NOT NULL,
+  costo_total NUMERIC(12,2) NOT NULL,
+  kilometraje_actual NUMERIC(12,2) NOT NULL,
+  kilometraje_anterior NUMERIC(12,2) DEFAULT 0,
+  rendimiento_km_galon NUMERIC(10,2),
+  foto_comprobante_url TEXT,
+  observaciones TEXT,
+  latitud NUMERIC(10,7),
+  longitud NUMERIC(10,7),
+  estado estado_combustible NOT NULL DEFAULT 'SINCRONIZADO',
+  sincronizado BOOLEAN NOT NULL DEFAULT TRUE,
+  registrado_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_combustible_galones CHECK (galones > 0),
+  CONSTRAINT chk_combustible_costo CHECK (costo_total >= 0),
+  CONSTRAINT chk_combustible_km CHECK (kilometraje_actual >= kilometraje_anterior)
+);
+
+-- =========================================================
+-- ÍNDICES
+-- =========================================================
+CREATE INDEX idx_usuarios_rol ON usuarios(rol);
+CREATE INDEX idx_usuarios_estado ON usuarios(estado);
+
+CREATE INDEX idx_sesiones_usuario ON sesiones_usuario(usuario_id);
+CREATE INDEX idx_sesiones_estado ON sesiones_usuario(estado);
+CREATE INDEX idx_reset_email ON password_reset_tokens(email);
+CREATE INDEX idx_auditoria_usuario ON auditoria_accesos(usuario_id);
+CREATE INDEX idx_auditoria_fecha ON auditoria_accesos(created_at);
+
+CREATE INDEX idx_conductores_estado_operacional ON conductores(estado_operacional);
+CREATE INDEX idx_contactos_emergencia_conductor ON contactos_emergencia(conductor_id);
+CREATE INDEX idx_licencias_conductor ON licencias_conducir(conductor_id);
+CREATE INDEX idx_licencias_vencimiento ON licencias_conducir(fecha_vencimiento);
+
+CREATE INDEX idx_unidades_estado ON unidades(estado);
+CREATE INDEX idx_unidades_gps_device ON unidades(gps_device_id);
+CREATE INDEX idx_camiones_unidad_id ON camiones(unidad_id);
+CREATE INDEX idx_camiones_estado ON camiones(estado);
+CREATE INDEX idx_mantenimientos_unidad ON camion_mantenimientos(unidad_id);
+
+CREATE INDEX idx_asignaciones_conductor ON asignaciones_conductor_unidad(conductor_id);
+CREATE INDEX idx_asignaciones_unidad ON asignaciones_conductor_unidad(unidad_id);
+CREATE UNIQUE INDEX uq_asignacion_activa_conductor
+  ON asignaciones_conductor_unidad(conductor_id)
+  WHERE estado = 'ACTIVA';
+CREATE UNIQUE INDEX uq_asignacion_activa_unidad
+  ON asignaciones_conductor_unidad(unidad_id)
+  WHERE estado = 'ACTIVA';
+
+CREATE INDEX idx_contratos_estado ON contratos(estado);
+CREATE INDEX idx_contratos_tipo_servicio ON contratos(tipo_servicio);
+CREATE UNIQUE INDEX uq_contrato_unidad_activa
+  ON contrato_unidades(contrato_id, unidad_id)
+  WHERE activo = TRUE;
+
+CREATE INDEX idx_jornadas_fecha ON jornadas(fecha_jornada);
+CREATE INDEX idx_jornadas_estado ON jornadas(estado);
+CREATE INDEX idx_jornadas_conductor ON jornadas(conductor_id);
+CREATE INDEX idx_jornadas_unidad ON jornadas(unidad_id);
+CREATE INDEX idx_jornadas_contrato ON jornadas(contrato_id);
+CREATE UNIQUE INDEX uq_jornada_activa_unidad
+  ON jornadas(unidad_id)
+  WHERE estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO');
+CREATE UNIQUE INDEX uq_jornada_activa_chofer
+  ON jornadas(conductor_id)
+  WHERE estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO');
+
+CREATE INDEX idx_alertas_jornada ON alertas_jornada(jornada_id);
+CREATE INDEX idx_alertas_tipo ON alertas_jornada(tipo);
+CREATE INDEX idx_alertas_estado ON alertas_jornada(estado);
+CREATE INDEX idx_alertas_fecha_hora ON alertas_jornada(fecha_hora);
+CREATE INDEX idx_alertas_historial_alerta ON alertas_historial(alerta_id);
+
+CREATE INDEX idx_ubicaciones_jornada ON ubicaciones_jornada(jornada_id);
+CREATE INDEX idx_ubicaciones_unidad ON ubicaciones_jornada(unidad_id);
+CREATE INDEX idx_ubicaciones_fecha_hora ON ubicaciones_jornada(fecha_hora);
+
+CREATE INDEX idx_gps_importacion_errores_importacion ON gps_importacion_errores(importacion_id);
+CREATE INDEX idx_gps_registros_unidad ON gps_registros(unidad_id);
+CREATE INDEX idx_gps_registros_jornada ON gps_registros(jornada_id);
+CREATE INDEX idx_gps_registros_fecha_hora ON gps_registros(fecha_hora);
+CREATE UNIQUE INDEX uq_gps_registros_proveedor_unidad_fecha
+  ON gps_registros(proveedor, unidad_id, fecha_hora);
+CREATE INDEX idx_gps_eventos_unidad ON gps_eventos(unidad_id);
+CREATE INDEX idx_gps_eventos_jornada ON gps_eventos(jornada_id);
+CREATE INDEX idx_gps_eventos_tipo ON gps_eventos(tipo_evento);
+
+CREATE INDEX idx_combustible_unidad ON combustible_registros(unidad_id);
+CREATE INDEX idx_combustible_conductor ON combustible_registros(conductor_id);
+CREATE INDEX idx_combustible_jornada ON combustible_registros(jornada_id);
+
+-- =========================================================
+-- TRIGGER GENERICO updated_at
+-- =========================================================
+CREATE OR REPLACE FUNCTION fn_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tg_usuarios_updated_at
+BEFORE UPDATE ON usuarios
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_conductores_updated_at
+BEFORE UPDATE ON conductores
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_licencias_updated_at
+BEFORE UPDATE ON licencias_conducir
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_gps_dispositivos_updated_at
+BEFORE UPDATE ON gps_dispositivos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_gps_proveedor_formatos_updated_at
+BEFORE UPDATE ON gps_proveedor_formatos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_unidades_updated_at
+BEFORE UPDATE ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_camiones_updated_at
+BEFORE UPDATE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_mantenimientos_updated_at
+BEFORE UPDATE ON camion_mantenimientos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_contratos_updated_at
+BEFORE UPDATE ON contratos
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+CREATE TRIGGER tg_jornadas_updated_at
+BEFORE UPDATE ON jornadas
+FOR EACH ROW EXECUTE FUNCTION fn_set_updated_at();
+
+-- =========================================================
+-- SINCRONIZACION unidades <-> camiones
+-- =========================================================
+CREATE OR REPLACE FUNCTION fn_map_camion_estado_to_unidad(p_estado TEXT)
+RETURNS estado_unidad AS $$
+BEGIN
+  RETURN CASE LOWER(COALESCE(p_estado, 'disponible'))
+    WHEN 'disponible' THEN 'DISPONIBLE'
+    WHEN 'available' THEN 'DISPONIBLE'
+    WHEN 'activo' THEN 'DISPONIBLE'
+    WHEN 'active' THEN 'DISPONIBLE'
+    WHEN 'en_uso' THEN 'EN_JORNADA'
+    WHEN 'in_use' THEN 'EN_JORNADA'
+    WHEN 'en_jornada' THEN 'EN_JORNADA'
+    WHEN 'en_auxilio' THEN 'EN_AUXILIO'
+    WHEN 'auxilio' THEN 'EN_AUXILIO'
+    WHEN 'mantenimiento' THEN 'MANTENIMIENTO'
+    WHEN 'maintenance' THEN 'MANTENIMIENTO'
+    ELSE 'INACTIVA'
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION fn_map_unidad_estado_to_camion(p_estado estado_unidad)
+RETURNS TEXT AS $$
+BEGIN
+  RETURN CASE p_estado
+    WHEN 'DISPONIBLE' THEN 'disponible'
+    WHEN 'EN_JORNADA' THEN 'en_uso'
+    WHEN 'EN_AUXILIO' THEN 'en_auxilio'
+    WHEN 'MANTENIMIENTO' THEN 'maintenance'
+    ELSE 'inactivo'
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION fn_sync_unidad_to_camion()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    ELSE
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO camiones (unidad_id, placa, marca, modelo, estado, created_at, updated_at)
+    VALUES (
+      NEW.id,
+      NEW.placa,
+      NEW.marca,
+      NEW.modelo,
+      fn_map_unidad_estado_to_camion(NEW.estado),
+      NEW.created_at,
+      NEW.updated_at
+    )
+    ON CONFLICT (unidad_id) DO UPDATE
+      SET placa = EXCLUDED.placa,
+          marca = EXCLUDED.marca,
+          modelo = EXCLUDED.modelo,
+          estado = EXCLUDED.estado,
+          updated_at = NOW();
+    RETURN NEW;
+  ELSIF TG_OP = 'UPDATE' THEN
+    UPDATE camiones
+       SET placa = NEW.placa,
+           marca = NEW.marca,
+           modelo = NEW.modelo,
+           estado = fn_map_unidad_estado_to_camion(NEW.estado),
+           updated_at = NOW()
+     WHERE unidad_id = NEW.id;
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    DELETE FROM camiones WHERE unidad_id = OLD.id;
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_before_insert()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_unidad_id UUID;
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.unidad_id IS NULL THEN
+    INSERT INTO unidades (
+      placa, marca, modelo, estado, gps_habilitado, activo, created_at, updated_at
+    )
+    VALUES (
+      NEW.placa,
+      NEW.marca,
+      NEW.modelo,
+      fn_map_camion_estado_to_unidad(NEW.estado),
+      TRUE,
+      TRUE,
+      COALESCE(NEW.created_at, NOW()),
+      COALESCE(NEW.updated_at, NOW())
+    )
+    RETURNING id INTO v_unidad_id;
+
+    NEW.unidad_id := v_unidad_id;
+  END IF;
+
+  NEW.created_at := COALESCE(NEW.created_at, NOW());
+  NEW.updated_at := COALESCE(NEW.updated_at, NOW());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_after_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE unidades
+     SET placa = NEW.placa,
+         marca = NEW.marca,
+         modelo = NEW.modelo,
+         estado = fn_map_camion_estado_to_unidad(NEW.estado),
+         updated_at = NOW()
+   WHERE id = NEW.unidad_id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_sync_camion_after_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF pg_trigger_depth() > 1 THEN
+    RETURN OLD;
+  END IF;
+
+  DELETE FROM unidades WHERE id = OLD.unidad_id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tg_unidad_to_camion_ins
+AFTER INSERT ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_unidad_to_camion_upd
+AFTER UPDATE ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_unidad_to_camion_del
+AFTER DELETE ON unidades
+FOR EACH ROW EXECUTE FUNCTION fn_sync_unidad_to_camion();
+
+CREATE TRIGGER tg_camion_before_insert
+BEFORE INSERT ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_before_insert();
+
+CREATE TRIGGER tg_camion_after_update
+AFTER UPDATE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_after_update();
+
+CREATE TRIGGER tg_camion_after_delete
+AFTER DELETE ON camiones
+FOR EACH ROW EXECUTE FUNCTION fn_sync_camion_after_delete();
+
+-- =========================================================
+-- VISTAS
+-- =========================================================
+CREATE OR REPLACE VIEW vw_conductores_full AS
+SELECT
+  u.id AS usuario_id,
+  u.cognito_sub,
+  u.correo,
+  u.nombres,
+  u.apellidos,
+  CONCAT(u.nombres, ' ', u.apellidos) AS nombre_completo,
+  u.telefono,
+  u.dni,
+  u.rol,
+  u.estado AS estado_usuario,
+  c.fecha_nacimiento,
+  c.direccion,
+  c.fecha_ingreso,
+  c.estado_operacional,
+  c.current_shift_id,
+  lc.numero_licencia,
+  lc.categoria AS licencia_categoria,
+  lc.fecha_vencimiento AS licencia_vencimiento,
+  ce.nombre AS contacto_emergencia_nombre,
+  ce.telefono AS contacto_emergencia_telefono,
+  ce.parentesco AS contacto_emergencia_parentesco,
+  a.unidad_id AS unidad_asignada_id,
+  un.placa AS placa_asignada
+FROM usuarios u
+JOIN conductores c ON c.usuario_id = u.id
+LEFT JOIN LATERAL (
+  SELECT l.*
+  FROM licencias_conducir l
+  WHERE l.conductor_id = c.usuario_id AND l.activa = TRUE
+  ORDER BY l.fecha_vencimiento DESC
+  LIMIT 1
+) lc ON TRUE
+LEFT JOIN LATERAL (
+  SELECT x.*
+  FROM contactos_emergencia x
+  WHERE x.conductor_id = c.usuario_id AND x.es_principal = TRUE
+  ORDER BY x.created_at DESC
+  LIMIT 1
+) ce ON TRUE
+LEFT JOIN LATERAL (
+  SELECT ac.*
+  FROM asignaciones_conductor_unidad ac
+  WHERE ac.conductor_id = c.usuario_id AND ac.estado = 'ACTIVA'
+  ORDER BY ac.fecha_inicio DESC
+  LIMIT 1
+) a ON TRUE
+LEFT JOIN unidades un ON un.id = a.unidad_id
+WHERE u.rol = 'CHOFER';
+
+CREATE OR REPLACE VIEW vw_camiones_operativos AS
+SELECT
+  un.id AS unidad_id,
+  c.id AS camion_legacy_id,
+  un.placa,
+  un.marca,
+  un.modelo,
+  un.anio,
+  un.capacidad_ton,
+  un.estado,
+  un.activo,
+  un.vin,
+  un.color,
+  un.tipo_combustible,
+  un.kilometraje_actual,
+  un.gps_habilitado,
+  gd.codigo_equipo AS gps_codigo_equipo,
+  gd.proveedor AS gps_proveedor,
+  un.ultima_fecha_mantenimiento,
+  un.proxima_fecha_mantenimiento
+FROM unidades un
+LEFT JOIN camiones c ON c.unidad_id = un.id
+LEFT JOIN gps_dispositivos gd ON gd.id = un.gps_device_id;
+
+CREATE OR REPLACE VIEW vw_historial_jornadas_chofer AS
+SELECT
+  j.id,
+  j.codigo,
+  j.conductor_id,
+  j.fecha_jornada,
+  j.origen,
+  j.destino,
+  j.hora_inicio,
+  j.hora_fin,
+  CASE
+    WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
+    THEN (j.hora_fin - j.hora_inicio)
+    ELSE NULL
+  END AS duracion_total,
+  j.km_recorridos,
+  j.observaciones,
+  j.estado,
+  j.unidad_id,
+  un.placa
+FROM jornadas j
+JOIN unidades un ON un.id = j.unidad_id
+WHERE j.estado = 'COMPLETADA';
+
+CREATE OR REPLACE VIEW vw_seguimiento_jornadas AS
+SELECT
+  j.id,
+  j.codigo,
+  j.fecha_jornada,
+  j.conductor_id,
+  CONCAT(u.nombres, ' ', u.apellidos) AS nombre_chofer,
+  j.unidad_id,
+  un.placa AS placa_camion,
+  un.marca,
+  un.modelo,
+  j.contrato_id,
+  c.codigo AS codigo_contrato,
+  c.cliente,
+  j.origen,
+  j.destino,
+  j.hora_inicio,
+  j.hora_fin,
+  CASE
+    WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
+    THEN (j.hora_fin - j.hora_inicio)
+    ELSE NULL
+  END AS duracion_total,
+  j.km_estimados,
+  j.km_recorridos,
+  j.estado,
+  j.observaciones,
+  EXISTS (
+    SELECT 1 FROM alertas_jornada a
+    WHERE a.jornada_id = j.id AND a.tipo = 'PANICO'
+  ) AS tiene_panico,
+  EXISTS (
+    SELECT 1 FROM alertas_jornada a
+    WHERE a.jornada_id = j.id AND a.tipo = 'AUXILIO_MECANICO'
+  ) AS tiene_auxilio,
+  (SELECT COUNT(*) FROM alertas_jornada a WHERE a.jornada_id = j.id) AS total_alertas
+FROM jornadas j
+JOIN usuarios u ON u.id = j.conductor_id
+JOIN unidades un ON un.id = j.unidad_id
+JOIN contratos c ON c.id = j.contrato_id
+ORDER BY j.fecha_jornada DESC, j.created_at DESC;
+
+CREATE OR REPLACE VIEW vw_tracking_gps AS
+SELECT
+  gr.id,
+  gr.unidad_id,
+  un.placa,
+  gr.jornada_id,
+  gr.fecha_hora,
+  gr.latitud,
+  gr.longitud,
+  gr.rumbo,
+  gr.velocidad_kmh,
+  gr.estado,
+  gr.odometro_km,
+  gr.proveedor
+FROM gps_registros gr
+JOIN unidades un ON un.id = gr.unidad_id;
+
+CREATE OR REPLACE VIEW vw_alertas_panel AS
+SELECT
+  a.id,
+  a.codigo,
+  a.jornada_id,
+  a.tipo,
+  a.estado,
+  a.severidad,
+  a.detalle,
+  a.tipo_falla_mecanica,
+  a.latitud,
+  a.longitud,
+  a.direccion,
+  a.fecha_hora,
+  a.atendida,
+  a.atendida_at,
+  j.unidad_id,
+  un.placa,
+  CONCAT(u.nombres, ' ', u.apellidos) AS conductor
+FROM alertas_jornada a
+JOIN jornadas j ON j.id = a.jornada_id
+JOIN unidades un ON un.id = j.unidad_id
+JOIN usuarios u ON u.id = j.conductor_id
+ORDER BY a.fecha_hora DESC;
+
+CREATE OR REPLACE VIEW vw_dashboard_resumen AS
+SELECT
+  (SELECT COUNT(*) FROM unidades WHERE activo = TRUE) AS total_camiones,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'EN_JORNADA') AS camiones_en_uso,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'DISPONIBLE') AS camiones_disponibles,
+  (SELECT COUNT(*) FROM unidades WHERE estado = 'MANTENIMIENTO') AS camiones_mantenimiento,
+  (SELECT COUNT(*) FROM usuarios WHERE rol = 'CHOFER' AND activo = TRUE) AS total_conductores,
+  (SELECT COUNT(*) FROM conductores WHERE estado_operacional = 'EN_RUTA') AS conductores_en_ruta,
+  (SELECT COUNT(*) FROM contratos WHERE estado = 'VIGENTE' AND activo = TRUE) AS contratos_activos,
+  (SELECT COUNT(*) FROM jornadas WHERE estado IN ('REGISTRADA','PENDIENTE','EN_PROCESO')) AS jornadas_activas,
+  (SELECT COUNT(*) FROM alertas_jornada WHERE estado IN ('ACTIVA','EN_PROCESO')) AS alertas_activas,
+  (SELECT COALESCE(SUM(km_recorridos), 0) FROM jornadas WHERE estado = 'COMPLETADA') AS km_totales_operados;

--- a/db/seed.mjs
+++ b/db/seed.mjs
@@ -4,11 +4,11 @@ export const seedSQL = `
 -- =========================================================
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', 'cognito-admin-001',   'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'cognito-driver-001',  'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
-('33333333-3333-3333-3333-333333333333', 'cognito-driver-002',  'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
-('44444444-4444-4444-4444-444444444444', 'cognito-driver-003',  'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
-('55555555-5555-5555-5555-555555555555', 'cognito-gerente-001', 'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
+('11111111-1111-1111-1111-111111111111', '7438d4b8-0021-7065-dda7-7bbdfa75c929', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002',               'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
+('44444444-4444-4444-4444-444444444444', 'cognito-sub-chofer-003',               'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
+('55555555-5555-5555-5555-555555555555', NULL,                                   'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
 -- =========================================================
 -- CONDUCTORES

--- a/db/seed.mjs
+++ b/db/seed.mjs
@@ -1,196 +1,373 @@
 export const seedSQL = `
--- ============================================
--- 12. DATOS DE PRUEBA
--- ============================================
-
--- Usuarios
+-- =========================================================
+-- USUARIOS
+-- =========================================================
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-(gen_random_uuid(), 'cognito-admin-001', 'admin@nanutech.com', 'Jimena', 'Rodriguez', 'ADMIN', '999111222', '70000001'),
-(gen_random_uuid(), 'cognito-driver-001', 'chofer1@nanutech.com', 'Carlos', 'Mendoza', 'CHOFER', '999222333', '70000002'),
-(gen_random_uuid(), 'cognito-driver-002', 'chofer2@nanutech.com', 'Luis', 'Ramirez', 'CHOFER', '999333444', '70000003'),
-(gen_random_uuid(), 'cognito-driver-003', 'chofer3@nanutech.com', 'Jorge', 'Silva', 'CHOFER', '999444555', '70000004');
+('11111111-1111-1111-1111-111111111111', 'cognito-admin-001',   'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'cognito-driver-001',  'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-driver-002',  'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
+('44444444-4444-4444-4444-444444444444', 'cognito-driver-003',  'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
+('55555555-5555-5555-5555-555555555555', 'cognito-gerente-001', 'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
--- Unidades
-INSERT INTO unidades (id, placa, marca, modelo, anio, capacidad_ton, estado)
+-- =========================================================
+-- CONDUCTORES
+-- =========================================================
+INSERT INTO conductores (usuario_id, fecha_nacimiento, direccion, fecha_ingreso, estado_operacional, observaciones)
 VALUES
-(gen_random_uuid(), 'ABC-123', 'Volvo', 'FH16', 2020, 20.00, 'DISPONIBLE'),
-(gen_random_uuid(), 'DEF-456', 'Scania', 'R450', 2021, 18.00, 'DISPONIBLE'),
-(gen_random_uuid(), 'GHI-789', 'Mercedes-Benz', 'Actros', 2019, 22.00, 'DISPONIBLE');
+('22222222-2222-2222-2222-222222222222', '1985-03-15', 'Av. Los Pinos 123, Lima',    '2020-01-15', 'DISPONIBLE', 'Conductor principal'),
+('33333333-3333-3333-3333-333333333333', '1988-07-22', 'Jr. Las Flores 456, Lima',   '2020-03-01', 'EN_RUTA',    'Conductor en jornada'),
+('44444444-4444-4444-4444-444444444444', '1982-11-10', 'Calle Los Alamos 789, Lima', '2019-06-15', 'DESCANSO',   'Conductor senior');
 
--- Contratos
-INSERT INTO contratos (id, codigo, cliente, descripcion, fecha_inicio, fecha_fin, tarifa, moneda, estado)
+INSERT INTO contactos_emergencia (conductor_id, nombre, telefono, parentesco, es_principal) VALUES
+('22222222-2222-2222-2222-222222222222', 'Maria Mendoza', '987111222', 'Esposa', TRUE),
+('33333333-3333-3333-3333-333333333333', 'Ana Ramirez',   '987222333', 'Hermana', TRUE),
+('44444444-4444-4444-4444-444444444444', 'Carmen Silva',  '987333444', 'Madre', TRUE);
+
+INSERT INTO licencias_conducir (conductor_id, numero_licencia, categoria, fecha_emision, fecha_vencimiento, autoridad_emisora, activa) VALUES
+('22222222-2222-2222-2222-222222222222', 'L45678901', 'A-III-b', '2022-01-10', '2027-01-10', 'MTC', TRUE),
+('33333333-3333-3333-3333-333333333333', 'L45678902', 'A-III-b', '2022-03-01', '2027-03-01', 'MTC', TRUE),
+('44444444-4444-4444-4444-444444444444', 'L45678903', 'A-III-c', '2021-08-15', '2026-08-15', 'MTC', TRUE);
+
+-- =========================================================
+-- GPS
+-- =========================================================
+INSERT INTO gps_dispositivos (id, codigo_equipo, proveedor, imei, numero_sim, activo)
 VALUES
-(gen_random_uuid(), 'CONT-001', 'Minera del Sur', 'Transporte de carga minera', '2026-01-01', '2026-12-31', 15000.00, 'PEN', 'VIGENTE'),
-(gen_random_uuid(), 'CONT-002', 'Logistica Andina', 'Distribucion interprovincial', '2026-02-01', '2026-10-31', 9800.00, 'PEN', 'VIGENTE');
+('90000000-0000-0000-0000-000000000001', 'GPS-2026-0001', 'GPSCONTROL', '359111111111111', '51990000001', TRUE),
+('90000000-0000-0000-0000-000000000002', 'GPS-2026-0002', 'GPSCONTROL', '359222222222222', '51990000002', TRUE),
+('90000000-0000-0000-0000-000000000003', 'GPS-2026-0003', 'GLOBALGPS',  '359333333333333', '51990000003', TRUE);
 
--- Jornada completada de ejemplo
-WITH
-admin_user AS (
-    SELECT id FROM usuarios WHERE correo = 'admin@nanutech.com'
-),
-driver_user AS (
-    SELECT id FROM usuarios WHERE correo = 'chofer1@nanutech.com'
-),
-truck_row AS (
-    SELECT id FROM unidades WHERE placa = 'ABC-123'
-),
-contract_row AS (
-    SELECT id FROM contratos WHERE codigo = 'CONT-001'
+-- =========================================================
+-- UNIDADES (triggers crean camiones automáticamente)
+-- =========================================================
+INSERT INTO unidades (
+  id, placa, marca, modelo, anio, capacidad_ton, estado, gps_habilitado, activo,
+  vin, color, tipo_combustible, fecha_registro,
+  ultima_fecha_mantenimiento, proxima_fecha_mantenimiento,
+  kilometraje_actual, gps_device_id, notas
 )
+VALUES
+('aaaa0001-0000-0000-0000-000000000001', 'ABC-123', 'Volvo',         'FH16',   2020, 20.00, 'DISPONIBLE',    TRUE, TRUE, 'VINVOLVO0001', 'Blanco', 'DIESEL', '2025-01-15', '2026-03-10', '2026-06-10', 25430.50, '90000000-0000-0000-0000-000000000001', 'Unidad operativa'),
+('aaaa0002-0000-0000-0000-000000000002', 'DEF-456', 'Scania',        'R450',   2021, 18.00, 'EN_JORNADA',    TRUE, TRUE, 'VINSCANIA02',  'Rojo',   'DIESEL', '2025-02-20', '2026-03-18', '2026-06-18', 18235.20, '90000000-0000-0000-0000-000000000002', 'Unidad en jornada'),
+('aaaa0003-0000-0000-0000-000000000003', 'GHI-789', 'Mercedes-Benz', 'Actros', 2019, 22.00, 'MANTENIMIENTO', TRUE, TRUE, 'VINMERCED03',  'Azul',   'DIESEL', '2025-03-10', '2026-04-01', '2026-05-15', 32150.75, '90000000-0000-0000-0000-000000000003', 'Unidad en mantenimiento');
+
+-- =========================================================
+-- ASIGNACIONES
+-- =========================================================
+INSERT INTO asignaciones_conductor_unidad (conductor_id, unidad_id, fecha_inicio, estado, creado_por, observaciones) VALUES
+('22222222-2222-2222-2222-222222222222', 'aaaa0001-0000-0000-0000-000000000001', '2026-04-20 08:00:00', 'ACTIVA', '11111111-1111-1111-1111-111111111111', 'Asignación principal'),
+('33333333-3333-3333-3333-333333333333', 'aaaa0002-0000-0000-0000-000000000002', '2026-04-20 08:00:00', 'ACTIVA', '11111111-1111-1111-1111-111111111111', 'Asignación principal');
+
+-- =========================================================
+-- CONTRATOS
+-- =========================================================
+INSERT INTO contratos (
+  id, codigo, cliente, ruc, descripcion, tipo_servicio, fecha_inicio, fecha_fin,
+  tarifa, moneda, estado, activo, updated_by
+)
+VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'CONT-2026-001', 'Minera del Sur',   '20123456789', 'Transporte de carga minera',   'POR_VIAJE', '2026-01-01', '2026-12-31', 15000.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111'),
+('bbbb0002-0000-0000-0000-000000000002', 'CONT-2026-002', 'Logistica Andina', '20987654321', 'Distribución interprovincial', 'POR_HORA',  '2026-02-01', '2026-10-31',  9800.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111'),
+('bbbb0003-0000-0000-0000-000000000003', 'CONT-2026-003', 'Agroexport Norte', '20456789123', 'Transporte por tonelada', 'POR_TONELADA', '2026-03-01', '2026-11-30', 12500.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111');
+
+INSERT INTO contrato_rutas (contrato_id, origen, destino, distancia_estimada_km) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'Lima', 'Arequipa', 520.00),
+('bbbb0002-0000-0000-0000-000000000002', 'Lima', 'Ica', 300.00),
+('bbbb0003-0000-0000-0000-000000000003', 'Trujillo', 'Piura', 420.00);
+
+INSERT INTO contrato_tarifas (contrato_id, tarifa_base, tarifa_por_km, tarifa_por_hora, tarifa_por_tonelada, tarifa_espera, total_referencial) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 15000.00, 0, 0, 0, 0, 15000.00),
+('bbbb0002-0000-0000-0000-000000000002', 5000.00, 0, 450.00, 0, 100.00, 9800.00),
+('bbbb0003-0000-0000-0000-000000000003', 3500.00, 0, 0, 180.00, 150.00, 12500.00);
+
+INSERT INTO contrato_unidades (contrato_id, unidad_id, assigned_by, activo) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '11111111-1111-1111-1111-111111111111', TRUE),
+('bbbb0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', '11111111-1111-1111-1111-111111111111', TRUE),
+('bbbb0003-0000-0000-0000-000000000003', 'aaaa0003-0000-0000-0000-000000000003', '11111111-1111-1111-1111-111111111111', TRUE);
+
+INSERT INTO contratos_historial (contrato_id, accion, campo, valor_anterior, valor_nuevo, detalle, usuario_id, ip_address) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'Creación de contrato', NULL, NULL, NULL, 'Contrato registrado en el sistema', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('bbbb0002-0000-0000-0000-000000000002', 'Asignación de unidad', 'unidad', NULL, 'DEF-456', 'Se asignó unidad al contrato', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('bbbb0003-0000-0000-0000-000000000003', 'Creación de tarifa', 'tarifa_por_tonelada', NULL, '180.00', 'Contrato configurado por tonelada', '11111111-1111-1111-1111-111111111111', '127.0.0.1');
+
+-- =========================================================
+-- JORNADAS
+-- =========================================================
 INSERT INTO jornadas (
-    conductor_id,
-    unidad_id,
-    contrato_id,
-    creado_por,
-    fecha_jornada,
-    hora_inicio,
-    hora_fin,
-    origen,
-    destino,
-    km_recorridos,
-    observaciones,
-    estado
+  id, codigo, conductor_id, unidad_id, contrato_id, creado_por,
+  fecha_jornada, hora_inicio_programada, hora_fin_programada,
+  hora_inicio, hora_fin, origen, destino,
+  km_estimados, km_recorridos, tipo_carga, peso_carga_ton,
+  observaciones, observacion_admin, estado
 )
-SELECT
-    d.id,
-    t.id,
-    c.id,
-    a.id,
-    CURRENT_DATE - 1,
-    (CURRENT_DATE - 1)::timestamp + INTERVAL '08 hours',
-    (CURRENT_DATE - 1)::timestamp + INTERVAL '18 hours 30 minutes',
-    'Lima',
-    'Arequipa',
-    525.40,
-    'Jornada completada sin incidencias mayores',
-    'COMPLETADA'
-FROM admin_user a, driver_user d, truck_row t, contract_row c;
-
--- Jornada activa de ejemplo
-WITH
-admin_user AS (
-    SELECT id FROM usuarios WHERE correo = 'admin@nanutech.com'
+VALUES
+(
+  'cccc0001-0000-0000-0000-000000000001',
+  'JOR-2026-0001',
+  '22222222-2222-2222-2222-222222222222',
+  'aaaa0001-0000-0000-0000-000000000001',
+  'bbbb0001-0000-0000-0000-000000000001',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-24',
+  '2026-04-24 08:00:00',
+  '2026-04-24 18:00:00',
+  '2026-04-24 08:05:00',
+  '2026-04-24 18:20:00',
+  'Lima',
+  'Arequipa',
+  520.00,
+  525.40,
+  'Mineral concentrado',
+  18.50,
+  'Jornada completada sin incidencias mayores',
+  'Cumplimiento correcto',
+  'COMPLETADA'
 ),
-driver_user AS (
-    SELECT id FROM usuarios WHERE correo = 'chofer2@nanutech.com'
+(
+  'cccc0002-0000-0000-0000-000000000002',
+  'JOR-2026-0002',
+  '33333333-3333-3333-3333-333333333333',
+  'aaaa0002-0000-0000-0000-000000000002',
+  'bbbb0002-0000-0000-0000-000000000002',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-26',
+  '2026-04-26 08:00:00',
+  '2026-04-26 16:00:00',
+  '2026-04-26 08:00:00',
+  NULL,
+  'Lima',
+  'Ica',
+  300.00,
+  120.80,
+  'Paquetería',
+  8.00,
+  'Jornada en curso',
+  NULL,
+  'EN_PROCESO'
 ),
-truck_row AS (
-    SELECT id FROM unidades WHERE placa = 'DEF-456'
-),
-contract_row AS (
-    SELECT id FROM contratos WHERE codigo = 'CONT-002'
-)
-INSERT INTO jornadas (
-    conductor_id,
-    unidad_id,
-    contrato_id,
-    creado_por,
-    fecha_jornada,
-    hora_inicio,
-    origen,
-    destino,
-    km_recorridos,
-    observaciones,
-    estado
-)
-SELECT
-    d.id,
-    t.id,
-    c.id,
-    a.id,
-    CURRENT_DATE,
-    CURRENT_TIMESTAMP - INTERVAL '3 hours',
-    'Lima',
-    'Ica',
-    120.80,
-    'Jornada en curso',
-    'EN_PROCESO'
-FROM admin_user a, driver_user d, truck_row t, contract_row c;
-
--- Actualizar estado de unidades según jornada activa
-UPDATE unidades
-SET estado = 'EN_JORNADA'
-WHERE id IN (
-    SELECT unidad_id
-    FROM jornadas
-    WHERE estado IN ('REGISTRADA', 'EN_PROCESO')
+(
+  'cccc0003-0000-0000-0000-000000000003',
+  'JOR-2026-0003',
+  '22222222-2222-2222-2222-222222222222',
+  'aaaa0001-0000-0000-0000-000000000001',
+  'bbbb0001-0000-0000-0000-000000000001',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-27',
+  '2026-04-27 08:00:00',
+  '2026-04-27 18:00:00',
+  NULL,
+  NULL,
+  'Lima',
+  'Arequipa',
+  520.00,
+  0,
+  'Mineral concentrado',
+  18.50,
+  NULL,
+  NULL,
+  'PENDIENTE'
 );
 
--- Insertar alerta para jornada activa
-WITH jornada_activa AS (
-    SELECT id
-    FROM jornadas
-    WHERE estado = 'EN_PROCESO'
-    ORDER BY created_at DESC
-    LIMIT 1
-)
+UPDATE conductores
+SET current_shift_id = 'cccc0002-0000-0000-0000-000000000002'
+WHERE usuario_id = '33333333-3333-3333-3333-333333333333';
+
+-- =========================================================
+-- ALERTAS
+-- =========================================================
 INSERT INTO alertas_jornada (
-    jornada_id,
-    tipo,
-    detalle,
-    latitud,
-    longitud,
-    fecha_hora,
-    atendida
+  id, codigo, jornada_id, tipo, estado, severidad, detalle,
+  tipo_falla_mecanica, latitud, longitud, direccion, fecha_hora,
+  atendida, atendida_por, atendida_at, detalle_resolucion,
+  servicio_tecnico_realizado, telefono_contactado, bloqueo_sos_activo
 )
-SELECT
-    id,
-    'AUXILIO_MECANICO',
-    'Falla mecanica reportada por el conductor',
-    -13.1588000,
-    -74.2236000,
-    CURRENT_TIMESTAMP - INTERVAL '1 hour',
-    FALSE
-FROM jornada_activa;
+VALUES
+(
+  'dddd0001-0000-0000-0000-000000000001',
+  'ALT-2026-0001',
+  'cccc0002-0000-0000-0000-000000000002',
+  'AUXILIO_MECANICO',
+  'ACTIVA',
+  'ALTA',
+  'Falla mecánica reportada por el conductor',
+  'Sobrecalentamiento',
+  -13.1588000,
+  -74.2236000,
+  'Km 250 Panamericana Sur',
+  '2026-04-26 09:10:00',
+  FALSE,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  FALSE
+),
+(
+  'dddd0002-0000-0000-0000-000000000002',
+  'ALT-2026-0002',
+  'cccc0001-0000-0000-0000-000000000001',
+  'PANICO',
+  'RESUELTA',
+  'CRITICA',
+  'Botón SOS activado por 3 segundos',
+  NULL,
+  -16.4090000,
+  -71.5370000,
+  'Ingreso a Arequipa',
+  '2026-04-24 17:10:00',
+  TRUE,
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-24 17:20:00',
+  'Alerta validada y cerrada por central',
+  'No aplica',
+  '999111222',
+  TRUE
+);
 
--- Ubicaciones para la jornada activa
-WITH jornada_activa AS (
-    SELECT id, hora_inicio
-    FROM jornadas
-    WHERE estado = 'EN_PROCESO'
-    ORDER BY created_at DESC
-    LIMIT 1
-)
+INSERT INTO alertas_historial (alerta_id, accion, detalle, usuario_id, created_at) VALUES
+('dddd0001-0000-0000-0000-000000000001', 'Registro de alerta', 'Se recibió auxilio mecánico en ruta', '33333333-3333-3333-3333-333333333333', '2026-04-26 09:10:00'),
+('dddd0002-0000-0000-0000-000000000002', 'Cierre de alerta', 'Alerta resuelta por central', '11111111-1111-1111-1111-111111111111', '2026-04-24 17:20:00');
+
+-- =========================================================
+-- UBICACIONES / GPS
+-- =========================================================
 INSERT INTO ubicaciones_jornada (
-    jornada_id,
-    latitud,
-    longitud,
-    fecha_hora,
-    tipo_registro,
-    velocidad_kmh
+  id, jornada_id, unidad_id, latitud, longitud, direccion,
+  fecha_hora, tipo_registro, velocidad_kmh, rumbo, odometro_km, proveedor
 )
-SELECT id, -12.0464000, -77.0428000, hora_inicio, 'INICIO'::tipo_registro_ubicacion, 0
-FROM jornada_activa
-UNION ALL
-SELECT id, -13.1588000, -74.2236000, CURRENT_TIMESTAMP - INTERVAL '1 hour', 'ALERTA'::tipo_registro_ubicacion, 45
-FROM jornada_activa
-UNION ALL
-SELECT id, -13.5319000, -71.9675000, CURRENT_TIMESTAMP, 'TRACKING'::tipo_registro_ubicacion, 62
-FROM jornada_activa;
--- ============================================
--- 13. CONSULTAS DE PRUEBA
--- ============================================
+VALUES
+('eeee0001-0000-0000-0000-000000000001', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -12.0464000, -77.0428000, 'Lima Centro',              '2026-04-26 08:00:00', 'INICIO',   0,   0, 18235.20, 'GPSCONTROL'),
+('eeee0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -13.1588000, -74.2236000, 'Km 250 Panamericana Sur', '2026-04-26 09:10:00', 'ALERTA',  45, 195, 18355.20, 'GPSCONTROL'),
+('eeee0003-0000-0000-0000-000000000003', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -13.5319000, -71.9675000, 'Tramo intermedio',         '2026-04-26 10:00:00', 'TRACKING',62, 180, 18410.60, 'GPSCONTROL'),
+('eeee0004-0000-0000-0000-000000000004', 'cccc0001-0000-0000-0000-000000000001', 'aaaa0001-0000-0000-0000-000000000001', -16.4090000, -71.5370000, 'Ingreso a Arequipa',       '2026-04-24 18:20:00', 'FIN',      0,   0, 25430.50, 'GPSCONTROL');
 
--- Ver usuarios
--- SELECT * FROM usuarios;
+INSERT INTO gps_importaciones (
+  id, proveedor, nombre_archivo, cargado_por, total_registros, registros_validos,
+  registros_invalidos, estado, observaciones, processed_at
+)
+VALUES
+(
+  'f1110001-0000-0000-0000-000000000001',
+  'GPSCONTROL',
+  'tracking_gps_2026-04-26.csv',
+  '11111111-1111-1111-1111-111111111111',
+  4, 4, 0, 'PROCESADA',
+  'Archivo cargado correctamente',
+  '2026-04-26 10:05:00'
+),
+(
+  'f1110002-0000-0000-0000-000000000002',
+  'GLOBALGPS',
+  'globalgps_ruta_arequipa_2026-04-24.xlsx',
+  '11111111-1111-1111-1111-111111111111',
+  5, 3, 2, 'PROCESADA_CON_ERRORES',
+  'Archivo procesado con filas observadas',
+  '2026-04-24 19:05:00'
+);
 
--- Ver unidades
--- SELECT * FROM unidades;
+INSERT INTO gps_proveedor_formatos (proveedor, nombre_formato, mapeo_columnas, activo)
+VALUES
+('GPSCONTROL', 'csv_tracking_v1', '{"unidad":"placa","fecha_hora":"fecha","latitud":"lat","longitud":"lon","velocidad_kmh":"velocidad","rumbo":"rumbo","odometro_km":"odometro"}', TRUE),
+('GLOBALGPS', 'xlsx_tracking_v2', '{"unidad":"vehicle_plate","fecha_hora":"event_time","latitud":"latitude","longitud":"longitude","velocidad_kmh":"speed","rumbo":"heading","odometro_km":"mileage"}', TRUE),
+('GPSCONTROL', 'csv_alertas_v1', '{"unidad":"placa","fecha_hora":"fecha_alerta","latitud":"lat","longitud":"lon","tipo_evento":"evento","detalle":"descripcion"}', TRUE);
 
--- Ver contratos
--- SELECT * FROM contratos;
+INSERT INTO gps_registros (
+  importacion_id, unidad_id, jornada_id, fecha_hora, latitud, longitud,
+  velocidad_kmh, rumbo, odometro_km, estado, proveedor, raw_payload
+)
+VALUES
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 08:00:00', -12.0464000, -77.0428000,  0,   0, 18235.20, 'DETENIDO', 'GPSCONTROL', '{"status":"stopped"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 09:00:00', -13.1588000, -74.2236000, 45, 195, 18355.20, 'MOVIENDO', 'GPSCONTROL', '{"status":"moving"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 09:30:00', -13.3000000, -73.5000000, 95, 180, 18390.20, 'EXCESO_VELOCIDAD', 'GPSCONTROL', '{"status":"speeding"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 10:00:00', -13.5319000, -71.9675000, 62, 180, 18410.60, 'MOVIENDO', 'GPSCONTROL', '{"status":"moving"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 08:05:00', -12.0464000, -77.0428000, 12, 150, 24910.10, 'MOVIENDO', 'GLOBALGPS', '{"status":"moving","source":"xlsx"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 10:30:00', -13.6500000, -75.2000000, 70, 165, 25120.40, 'MOVIENDO', 'GLOBALGPS', '{"status":"moving","source":"xlsx"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 18:20:00', -16.4090000, -71.5370000, 0, 180, 25430.50, 'DETENIDO', 'GLOBALGPS', '{"status":"stopped","source":"xlsx"}');
 
--- Ver jornadas
--- SELECT * FROM jornadas ORDER BY created_at DESC;
+INSERT INTO gps_importacion_errores (
+  importacion_id, numero_fila, campo, valor_recibido, motivo_error, raw_payload
+)
+VALUES
+('f1110002-0000-0000-0000-000000000002', 4, 'latitud', 'N/A', 'Latitud no numerica', '{"vehicle_plate":"ABC-123","event_time":"2026-04-24 12:00:00","latitude":"N/A","longitude":"-74.990000"}'),
+('f1110002-0000-0000-0000-000000000002', 5, 'fecha_hora', '24/04/2026 25:90', 'Fecha u hora invalida', '{"vehicle_plate":"ABC-123","event_time":"24/04/2026 25:90","latitude":"-14.100000","longitude":"-74.500000"}');
 
--- Ver seguimiento
--- SELECT * FROM vw_seguimiento_jornadas;
+INSERT INTO gps_eventos (
+  unidad_id, jornada_id, tipo_evento, estado, fecha_hora_inicio, fecha_hora_fin,
+  velocidad_maxima, latitud, longitud, distancia_km, detalle
+)
+VALUES
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'DETENCION',         'DETENIDO',          '2026-04-26 08:00:00', '2026-04-26 08:05:00', 0,  -12.0464000, -77.0428000, 0.00, 'Unidad detenida antes de iniciar desplazamiento'),
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'MOVIMIENTO',        'MOVIENDO',          '2026-04-26 08:05:00', '2026-04-26 09:25:00', 62, -13.1588000, -74.2236000, 120.80, 'Desplazamiento normal'),
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'EXCESO_VELOCIDAD', 'EXCESO_VELOCIDAD', '2026-04-26 09:25:00', '2026-04-26 09:32:00', 95, -13.3000000, -73.5000000, 12.00, 'Velocidad mayor a 90 km/h');
 
--- Ver alertas por jornada
--- SELECT * FROM alertas_jornada ORDER BY fecha_hora DESC;
+-- =========================================================
+-- COMBUSTIBLE
+-- =========================================================
+INSERT INTO combustible_registros (
+  id, jornada_id, unidad_id, conductor_id, contrato_id, tipo_comprobante, numero_comprobante,
+  galones, costo_total, kilometraje_actual, kilometraje_anterior, rendimiento_km_galon,
+  foto_comprobante_url, observaciones, latitud, longitud, estado, sincronizado, registrado_at
+)
+VALUES
+(
+  'f2110001-0000-0000-0000-000000000001',
+  'cccc0002-0000-0000-0000-000000000002',
+  'aaaa0002-0000-0000-0000-000000000002',
+  '33333333-3333-3333-3333-333333333333',
+  'bbbb0002-0000-0000-0000-000000000002',
+  'TICKET',
+  'TCK-0001',
+  18.50,
+  420.00,
+  18355.20,
+  18235.20,
+  6.49,
+  'https://example.com/combustible/tck-0001.jpg',
+  'Carga parcial en ruta',
+  -13.1588000,
+  -74.2236000,
+  'SINCRONIZADO',
+  TRUE,
+  '2026-04-26 09:12:00'
+);
 
--- Ver tracking GPS
--- SELECT * FROM ubicaciones_jornada ORDER BY fecha_hora DESC;
+-- =========================================================
+-- MANTENIMIENTO
+-- =========================================================
+INSERT INTO camion_mantenimientos (
+  unidad_id, tipo, fecha_programada, fecha_ejecutada, kilometraje, costo, proveedor_taller, observaciones
+)
+VALUES
+('aaaa0003-0000-0000-0000-000000000003', 'PREVENTIVO', '2026-04-28', NULL, 32150.75, NULL, 'Taller Volvo Lima', 'Cambio de filtros y revisión general'),
+('aaaa0001-0000-0000-0000-000000000001', 'INSPECCION', '2026-03-10', '2026-03-10', 25000.00, 350.00, 'Taller Norte', 'Inspección rutinaria');
 
+-- =========================================================
+-- AUDITORIA / SESIONES
+-- =========================================================
+INSERT INTO auditoria_accesos (usuario_id, correo, rol, accion, resultado, ip_address, user_agent, dispositivo, detalle)
+VALUES
+('11111111-1111-1111-1111-111111111111', 'admin@nanutech.com',   'ADMIN',   'LOGIN',             'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Inicio de sesión correcto'),
+('33333333-3333-3333-3333-333333333333', 'chofer2@nanutech.com', 'CHOFER',  'INICIAR_JORNADA',   'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Android',        'Jornada iniciada desde panel chofer'),
+('55555555-5555-5555-5555-555555555555', 'gerencia@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
+
+INSERT INTO login_intentos (email, intentos_fallidos, ultimo_intento, bloqueado_hasta)
+VALUES ('invalido@nanutech.com', 2, NOW() - INTERVAL '2 hours', NULL);
+
+INSERT INTO password_reset_tokens (usuario_id, email, token, expira_at, usado)
+VALUES ('22222222-2222-2222-2222-222222222222', 'chofer1@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
+
+INSERT INTO sesiones_usuario (usuario_id, access_token_jti, refresh_token_jti, expira_at, ultimo_evento_at, estado)
+VALUES
+('11111111-1111-1111-1111-111111111111', 'JTI-ACCESS-ADMIN-001', 'JTI-REFRESH-ADMIN-001', NOW() + INTERVAL '8 hours', NOW(), 'ACTIVA'),
+('33333333-3333-3333-3333-333333333333', 'JTI-ACCESS-DRV-002',   'JTI-REFRESH-DRV-002',   NOW() + INTERVAL '8 hours', NOW(), 'ACTIVA');
+
+-- =========================================================
+-- HISTORIAL DE CONDUCTORES
+-- =========================================================
+INSERT INTO conductores_historial (conductor_id, accion, campo, valor_anterior, valor_nuevo, detalle, usuario_id, ip_address)
+VALUES
+('22222222-2222-2222-2222-222222222222', 'Actualización de estado operacional', 'estado_operacional', 'DISPONIBLE', 'DISPONIBLE', 'Validación administrativa', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('33333333-3333-3333-3333-333333333333', 'Asignación de jornada', 'current_shift_id', NULL, 'cccc0002-0000-0000-0000-000000000002', 'Conductor asignado a jornada activa', '11111111-1111-1111-1111-111111111111', '127.0.0.1');
 `;

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -3,11 +3,11 @@
 -- =========================================================
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', 'cognito-admin-001',   'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'cognito-driver-001',  'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
-('33333333-3333-3333-3333-333333333333', 'cognito-driver-002',  'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
-('44444444-4444-4444-4444-444444444444', 'cognito-driver-003',  'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
-('55555555-5555-5555-5555-555555555555', 'cognito-gerente-001', 'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
+('11111111-1111-1111-1111-111111111111', '7438d4b8-0021-7065-dda7-7bbdfa75c929', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002',               'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
+('44444444-4444-4444-4444-444444444444', 'cognito-sub-chofer-003',               'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
+('55555555-5555-5555-5555-555555555555', NULL,                                   'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
 -- =========================================================
 -- CONDUCTORES

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,142 +1,371 @@
--- ============================================
--- NANUTECH - SEED PARA TESTS (pg-mem)
--- Sin CTEs complejos, sin casts de enum,
--- sin operaciones de fecha complejas
--- ============================================
-
--- ============================================
--- 1. USUARIOS
--- ============================================
-
+-- =========================================================
+-- USUARIOS
+-- =========================================================
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', 'cognito-admin-001', 'admin@nanutech.com', 'Jimena', 'Rodriguez', 'ADMIN', '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'cognito-driver-001', 'chofer1@nanutech.com', 'Carlos', 'Mendoza', 'CHOFER', '999222333', '70000002'),
-('33333333-3333-3333-3333-333333333333', 'cognito-driver-002', 'chofer2@nanutech.com', 'Luis', 'Ramirez', 'CHOFER', '999333444', '70000003'),
-('44444444-4444-4444-4444-444444444444', 'cognito-driver-003', 'chofer3@nanutech.com', 'Jorge', 'Silva', 'CHOFER', '999444555', '70000004');
+('11111111-1111-1111-1111-111111111111', 'cognito-admin-001',   'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'cognito-driver-001',  'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-driver-002',  'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
+('44444444-4444-4444-4444-444444444444', 'cognito-driver-003',  'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
+('55555555-5555-5555-5555-555555555555', 'cognito-gerente-001', 'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
--- ============================================
--- 2. UNIDADES
--- ============================================
-
-INSERT INTO unidades (id, placa, marca, modelo, anio, capacidad_ton, estado)
+-- =========================================================
+-- CONDUCTORES
+-- =========================================================
+INSERT INTO conductores (usuario_id, fecha_nacimiento, direccion, fecha_ingreso, estado_operacional, observaciones)
 VALUES
-('aaaa0001-0000-0000-0000-000000000001', 'ABC-123', 'Volvo', 'FH16', 2020, 20.00, 'DISPONIBLE'),
-('aaaa0002-0000-0000-0000-000000000002', 'DEF-456', 'Scania', 'R450', 2021, 18.00, 'DISPONIBLE'),
-('aaaa0003-0000-0000-0000-000000000003', 'GHI-789', 'Mercedes-Benz', 'Actros', 2019, 22.00, 'DISPONIBLE');
+('22222222-2222-2222-2222-222222222222', '1985-03-15', 'Av. Los Pinos 123, Lima',    '2020-01-15', 'DISPONIBLE', 'Conductor principal'),
+('33333333-3333-3333-3333-333333333333', '1988-07-22', 'Jr. Las Flores 456, Lima',   '2020-03-01', 'EN_RUTA',    'Conductor en jornada'),
+('44444444-4444-4444-4444-444444444444', '1982-11-10', 'Calle Los Alamos 789, Lima', '2019-06-15', 'DESCANSO',   'Conductor senior');
 
--- ============================================
--- 3. CONTRATOS
--- ============================================
+INSERT INTO contactos_emergencia (conductor_id, nombre, telefono, parentesco, es_principal) VALUES
+('22222222-2222-2222-2222-222222222222', 'Maria Mendoza', '987111222', 'Esposa', TRUE),
+('33333333-3333-3333-3333-333333333333', 'Ana Ramirez',   '987222333', 'Hermana', TRUE),
+('44444444-4444-4444-4444-444444444444', 'Carmen Silva',  '987333444', 'Madre', TRUE);
 
-INSERT INTO contratos (id, codigo, cliente, descripcion, fecha_inicio, fecha_fin, tarifa, moneda, estado)
+INSERT INTO licencias_conducir (conductor_id, numero_licencia, categoria, fecha_emision, fecha_vencimiento, autoridad_emisora, activa) VALUES
+('22222222-2222-2222-2222-222222222222', 'L45678901', 'A-III-b', '2022-01-10', '2027-01-10', 'MTC', TRUE),
+('33333333-3333-3333-3333-333333333333', 'L45678902', 'A-III-b', '2022-03-01', '2027-03-01', 'MTC', TRUE),
+('44444444-4444-4444-4444-444444444444', 'L45678903', 'A-III-c', '2021-08-15', '2026-08-15', 'MTC', TRUE);
+
+-- =========================================================
+-- GPS
+-- =========================================================
+INSERT INTO gps_dispositivos (id, codigo_equipo, proveedor, imei, numero_sim, activo)
 VALUES
-('bbbb0001-0000-0000-0000-000000000001', 'CONT-001', 'Minera del Sur', 'Transporte de carga minera', '2026-01-01', '2026-12-31', 15000.00, 'PEN', 'VIGENTE'),
-('bbbb0002-0000-0000-0000-000000000002', 'CONT-002', 'Logistica Andina', 'Distribucion interprovincial', '2026-02-01', '2026-10-31', 9800.00, 'PEN', 'VIGENTE');
+('90000000-0000-0000-0000-000000000001', 'GPS-2026-0001', 'GPSCONTROL', '359111111111111', '51990000001', TRUE),
+('90000000-0000-0000-0000-000000000002', 'GPS-2026-0002', 'GPSCONTROL', '359222222222222', '51990000002', TRUE),
+('90000000-0000-0000-0000-000000000003', 'GPS-2026-0003', 'GLOBALGPS',  '359333333333333', '51990000003', TRUE);
 
--- ============================================
--- 4. JORNADA COMPLETADA
--- ============================================
-
-INSERT INTO jornadas (
-    id, conductor_id, unidad_id, contrato_id, creado_por,
-    fecha_jornada, hora_inicio, hora_fin,
-    origen, destino, km_recorridos, observaciones, estado
+-- =========================================================
+-- UNIDADES (triggers crean camiones automáticamente)
+-- =========================================================
+INSERT INTO unidades (
+  id, placa, marca, modelo, anio, capacidad_ton, estado, gps_habilitado, activo,
+  vin, color, tipo_combustible, fecha_registro,
+  ultima_fecha_mantenimiento, proxima_fecha_mantenimiento,
+  kilometraje_actual, gps_device_id, notas
 )
-VALUES (
-    'cccc0001-0000-0000-0000-000000000001',
-    '22222222-2222-2222-2222-222222222222',
-    'aaaa0001-0000-0000-0000-000000000001',
-    'bbbb0001-0000-0000-0000-000000000001',
-    '11111111-1111-1111-1111-111111111111',
-    '2026-04-04',
-    '2026-04-04 08:00:00',
-    '2026-04-04 18:30:00',
-    'Lima', 'Arequipa', 525.40,
-    'Jornada completada sin incidencias mayores',
-    'COMPLETADA'
+VALUES
+('aaaa0001-0000-0000-0000-000000000001', 'ABC-123', 'Volvo',         'FH16',   2020, 20.00, 'DISPONIBLE',    TRUE, TRUE, 'VINVOLVO0001', 'Blanco', 'DIESEL', '2025-01-15', '2026-03-10', '2026-06-10', 25430.50, '90000000-0000-0000-0000-000000000001', 'Unidad operativa'),
+('aaaa0002-0000-0000-0000-000000000002', 'DEF-456', 'Scania',        'R450',   2021, 18.00, 'EN_JORNADA',    TRUE, TRUE, 'VINSCANIA02',  'Rojo',   'DIESEL', '2025-02-20', '2026-03-18', '2026-06-18', 18235.20, '90000000-0000-0000-0000-000000000002', 'Unidad en jornada'),
+('aaaa0003-0000-0000-0000-000000000003', 'GHI-789', 'Mercedes-Benz', 'Actros', 2019, 22.00, 'MANTENIMIENTO', TRUE, TRUE, 'VINMERCED03',  'Azul',   'DIESEL', '2025-03-10', '2026-04-01', '2026-05-15', 32150.75, '90000000-0000-0000-0000-000000000003', 'Unidad en mantenimiento');
+
+-- =========================================================
+-- ASIGNACIONES
+-- =========================================================
+INSERT INTO asignaciones_conductor_unidad (conductor_id, unidad_id, fecha_inicio, estado, creado_por, observaciones) VALUES
+('22222222-2222-2222-2222-222222222222', 'aaaa0001-0000-0000-0000-000000000001', '2026-04-20 08:00:00', 'ACTIVA', '11111111-1111-1111-1111-111111111111', 'Asignación principal'),
+('33333333-3333-3333-3333-333333333333', 'aaaa0002-0000-0000-0000-000000000002', '2026-04-20 08:00:00', 'ACTIVA', '11111111-1111-1111-1111-111111111111', 'Asignación principal');
+
+-- =========================================================
+-- CONTRATOS
+-- =========================================================
+INSERT INTO contratos (
+  id, codigo, cliente, ruc, descripcion, tipo_servicio, fecha_inicio, fecha_fin,
+  tarifa, moneda, estado, activo, updated_by
+)
+VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'CONT-2026-001', 'Minera del Sur',   '20123456789', 'Transporte de carga minera',   'POR_VIAJE', '2026-01-01', '2026-12-31', 15000.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111'),
+('bbbb0002-0000-0000-0000-000000000002', 'CONT-2026-002', 'Logistica Andina', '20987654321', 'Distribución interprovincial', 'POR_HORA',  '2026-02-01', '2026-10-31',  9800.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111'),
+('bbbb0003-0000-0000-0000-000000000003', 'CONT-2026-003', 'Agroexport Norte', '20456789123', 'Transporte por tonelada', 'POR_TONELADA', '2026-03-01', '2026-11-30', 12500.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111');
+
+INSERT INTO contrato_rutas (contrato_id, origen, destino, distancia_estimada_km) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'Lima', 'Arequipa', 520.00),
+('bbbb0002-0000-0000-0000-000000000002', 'Lima', 'Ica', 300.00),
+('bbbb0003-0000-0000-0000-000000000003', 'Trujillo', 'Piura', 420.00);
+
+INSERT INTO contrato_tarifas (contrato_id, tarifa_base, tarifa_por_km, tarifa_por_hora, tarifa_por_tonelada, tarifa_espera, total_referencial) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 15000.00, 0, 0, 0, 0, 15000.00),
+('bbbb0002-0000-0000-0000-000000000002', 5000.00, 0, 450.00, 0, 100.00, 9800.00),
+('bbbb0003-0000-0000-0000-000000000003', 3500.00, 0, 0, 180.00, 150.00, 12500.00);
+
+INSERT INTO contrato_unidades (contrato_id, unidad_id, assigned_by, activo) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '11111111-1111-1111-1111-111111111111', TRUE),
+('bbbb0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', '11111111-1111-1111-1111-111111111111', TRUE),
+('bbbb0003-0000-0000-0000-000000000003', 'aaaa0003-0000-0000-0000-000000000003', '11111111-1111-1111-1111-111111111111', TRUE);
+
+INSERT INTO contratos_historial (contrato_id, accion, campo, valor_anterior, valor_nuevo, detalle, usuario_id, ip_address) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'Creación de contrato', NULL, NULL, NULL, 'Contrato registrado en el sistema', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('bbbb0002-0000-0000-0000-000000000002', 'Asignación de unidad', 'unidad', NULL, 'DEF-456', 'Se asignó unidad al contrato', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('bbbb0003-0000-0000-0000-000000000003', 'Creación de tarifa', 'tarifa_por_tonelada', NULL, '180.00', 'Contrato configurado por tonelada', '11111111-1111-1111-1111-111111111111', '127.0.0.1');
+
+-- =========================================================
+-- JORNADAS
+-- =========================================================
+INSERT INTO jornadas (
+  id, codigo, conductor_id, unidad_id, contrato_id, creado_por,
+  fecha_jornada, hora_inicio_programada, hora_fin_programada,
+  hora_inicio, hora_fin, origen, destino,
+  km_estimados, km_recorridos, tipo_carga, peso_carga_ton,
+  observaciones, observacion_admin, estado
+)
+VALUES
+(
+  'cccc0001-0000-0000-0000-000000000001',
+  'JOR-2026-0001',
+  '22222222-2222-2222-2222-222222222222',
+  'aaaa0001-0000-0000-0000-000000000001',
+  'bbbb0001-0000-0000-0000-000000000001',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-24',
+  '2026-04-24 08:00:00',
+  '2026-04-24 18:00:00',
+  '2026-04-24 08:05:00',
+  '2026-04-24 18:20:00',
+  'Lima',
+  'Arequipa',
+  520.00,
+  525.40,
+  'Mineral concentrado',
+  18.50,
+  'Jornada completada sin incidencias mayores',
+  'Cumplimiento correcto',
+  'COMPLETADA'
+),
+(
+  'cccc0002-0000-0000-0000-000000000002',
+  'JOR-2026-0002',
+  '33333333-3333-3333-3333-333333333333',
+  'aaaa0002-0000-0000-0000-000000000002',
+  'bbbb0002-0000-0000-0000-000000000002',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-26',
+  '2026-04-26 08:00:00',
+  '2026-04-26 16:00:00',
+  '2026-04-26 08:00:00',
+  NULL,
+  'Lima',
+  'Ica',
+  300.00,
+  120.80,
+  'Paquetería',
+  8.00,
+  'Jornada en curso',
+  NULL,
+  'EN_PROCESO'
+),
+(
+  'cccc0003-0000-0000-0000-000000000003',
+  'JOR-2026-0003',
+  '22222222-2222-2222-2222-222222222222',
+  'aaaa0001-0000-0000-0000-000000000001',
+  'bbbb0001-0000-0000-0000-000000000001',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-27',
+  '2026-04-27 08:00:00',
+  '2026-04-27 18:00:00',
+  NULL,
+  NULL,
+  'Lima',
+  'Arequipa',
+  520.00,
+  0,
+  'Mineral concentrado',
+  18.50,
+  NULL,
+  NULL,
+  'PENDIENTE'
 );
 
--- ============================================
--- 5. JORNADA EN PROCESO
--- ============================================
+UPDATE conductores
+SET current_shift_id = 'cccc0002-0000-0000-0000-000000000002'
+WHERE usuario_id = '33333333-3333-3333-3333-333333333333';
 
-INSERT INTO jornadas (
-    id, conductor_id, unidad_id, contrato_id, creado_por,
-    fecha_jornada, hora_inicio,
-    origen, destino, km_recorridos, observaciones, estado
-)
-VALUES (
-    'cccc0002-0000-0000-0000-000000000002',
-    '33333333-3333-3333-3333-333333333333',
-    'aaaa0002-0000-0000-0000-000000000002',
-    'bbbb0002-0000-0000-0000-000000000002',
-    '11111111-1111-1111-1111-111111111111',
-    '2026-04-05',
-    '2026-04-05 08:00:00',
-    'Lima', 'Ica', 120.80,
-    'Jornada en curso',
-    'EN_PROCESO'
-);
-
--- ============================================
--- 6. ACTUALIZAR UNIDAD EN JORNADA
--- ============================================
-
-UPDATE unidades
-SET estado = 'EN_JORNADA'
-WHERE id = 'aaaa0002-0000-0000-0000-000000000002';
-
--- ============================================
--- 7. ALERTA PARA JORNADA EN PROCESO
--- ============================================
-
+-- =========================================================
+-- ALERTAS
+-- =========================================================
 INSERT INTO alertas_jornada (
-    id, jornada_id, tipo, detalle,
-    latitud, longitud, fecha_hora, atendida
-)
-VALUES (
-    'dddd0001-0000-0000-0000-000000000001',
-    'cccc0002-0000-0000-0000-000000000002',
-    'AUXILIO_MECANICO',
-    'Falla mecanica reportada por el conductor',
-    -13.1588000, -74.2236000,
-    '2026-04-05 09:00:00',
-    FALSE
-);
-
--- ============================================
--- 8. UBICACIONES GPS
--- ============================================
-
-INSERT INTO ubicaciones_jornada (
-    id, jornada_id, latitud, longitud,
-    fecha_hora, tipo_registro, velocidad_kmh
+  id, codigo, jornada_id, tipo, estado, severidad, detalle,
+  tipo_falla_mecanica, latitud, longitud, direccion, fecha_hora,
+  atendida, atendida_por, atendida_at, detalle_resolucion,
+  servicio_tecnico_realizado, telefono_contactado, bloqueo_sos_activo
 )
 VALUES
 (
-    'eeee0001-0000-0000-0000-000000000001',
-    'cccc0002-0000-0000-0000-000000000002',
-    -12.0464000, -77.0428000,
-    '2026-04-05 08:00:00',
-    'INICIO', 0
+  'dddd0001-0000-0000-0000-000000000001',
+  'ALT-2026-0001',
+  'cccc0002-0000-0000-0000-000000000002',
+  'AUXILIO_MECANICO',
+  'ACTIVA',
+  'ALTA',
+  'Falla mecánica reportada por el conductor',
+  'Sobrecalentamiento',
+  -13.1588000,
+  -74.2236000,
+  'Km 250 Panamericana Sur',
+  '2026-04-26 09:10:00',
+  FALSE,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  FALSE
 ),
 (
-    'eeee0002-0000-0000-0000-000000000002',
-    'cccc0002-0000-0000-0000-000000000002',
-    -13.1588000, -74.2236000,
-    '2026-04-05 09:00:00',
-    'ALERTA', 45
-),
-(
-    'eeee0003-0000-0000-0000-000000000003',
-    'cccc0002-0000-0000-0000-000000000002',
-    -13.5319000, -71.9675000,
-    '2026-04-05 10:00:00',
-    'TRACKING', 62
+  'dddd0002-0000-0000-0000-000000000002',
+  'ALT-2026-0002',
+  'cccc0001-0000-0000-0000-000000000001',
+  'PANICO',
+  'RESUELTA',
+  'CRITICA',
+  'Botón SOS activado por 3 segundos',
+  NULL,
+  -16.4090000,
+  -71.5370000,
+  'Ingreso a Arequipa',
+  '2026-04-24 17:10:00',
+  TRUE,
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-24 17:20:00',
+  'Alerta validada y cerrada por central',
+  'No aplica',
+  '999111222',
+  TRUE
 );
 
+INSERT INTO alertas_historial (alerta_id, accion, detalle, usuario_id, created_at) VALUES
+('dddd0001-0000-0000-0000-000000000001', 'Registro de alerta', 'Se recibió auxilio mecánico en ruta', '33333333-3333-3333-3333-333333333333', '2026-04-26 09:10:00'),
+('dddd0002-0000-0000-0000-000000000002', 'Cierre de alerta', 'Alerta resuelta por central', '11111111-1111-1111-1111-111111111111', '2026-04-24 17:20:00');
 
-INSERT INTO camiones (id, placa, marca, modelo, anio, capacidad_ton, estado) VALUES
-('1', 'ABC-123', 'Volvo', 'FH16', 2022, 20, 'DISPONIBLE'),
-('2', 'XYZ-789', 'Scania', 'R450', 2023, 18, 'DISPONIBLE');
+-- =========================================================
+-- UBICACIONES / GPS
+-- =========================================================
+INSERT INTO ubicaciones_jornada (
+  id, jornada_id, unidad_id, latitud, longitud, direccion,
+  fecha_hora, tipo_registro, velocidad_kmh, rumbo, odometro_km, proveedor
+)
+VALUES
+('eeee0001-0000-0000-0000-000000000001', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -12.0464000, -77.0428000, 'Lima Centro',              '2026-04-26 08:00:00', 'INICIO',   0,   0, 18235.20, 'GPSCONTROL'),
+('eeee0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -13.1588000, -74.2236000, 'Km 250 Panamericana Sur', '2026-04-26 09:10:00', 'ALERTA',  45, 195, 18355.20, 'GPSCONTROL'),
+('eeee0003-0000-0000-0000-000000000003', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -13.5319000, -71.9675000, 'Tramo intermedio',         '2026-04-26 10:00:00', 'TRACKING',62, 180, 18410.60, 'GPSCONTROL'),
+('eeee0004-0000-0000-0000-000000000004', 'cccc0001-0000-0000-0000-000000000001', 'aaaa0001-0000-0000-0000-000000000001', -16.4090000, -71.5370000, 'Ingreso a Arequipa',       '2026-04-24 18:20:00', 'FIN',      0,   0, 25430.50, 'GPSCONTROL');
+
+INSERT INTO gps_importaciones (
+  id, proveedor, nombre_archivo, cargado_por, total_registros, registros_validos,
+  registros_invalidos, estado, observaciones, processed_at
+)
+VALUES
+(
+  'f1110001-0000-0000-0000-000000000001',
+  'GPSCONTROL',
+  'tracking_gps_2026-04-26.csv',
+  '11111111-1111-1111-1111-111111111111',
+  4, 4, 0, 'PROCESADA',
+  'Archivo cargado correctamente',
+  '2026-04-26 10:05:00'
+),
+(
+  'f1110002-0000-0000-0000-000000000002',
+  'GLOBALGPS',
+  'globalgps_ruta_arequipa_2026-04-24.xlsx',
+  '11111111-1111-1111-1111-111111111111',
+  5, 3, 2, 'PROCESADA_CON_ERRORES',
+  'Archivo procesado con filas observadas',
+  '2026-04-24 19:05:00'
+);
+
+INSERT INTO gps_proveedor_formatos (proveedor, nombre_formato, mapeo_columnas, activo)
+VALUES
+('GPSCONTROL', 'csv_tracking_v1', '{"unidad":"placa","fecha_hora":"fecha","latitud":"lat","longitud":"lon","velocidad_kmh":"velocidad","rumbo":"rumbo","odometro_km":"odometro"}', TRUE),
+('GLOBALGPS', 'xlsx_tracking_v2', '{"unidad":"vehicle_plate","fecha_hora":"event_time","latitud":"latitude","longitud":"longitude","velocidad_kmh":"speed","rumbo":"heading","odometro_km":"mileage"}', TRUE),
+('GPSCONTROL', 'csv_alertas_v1', '{"unidad":"placa","fecha_hora":"fecha_alerta","latitud":"lat","longitud":"lon","tipo_evento":"evento","detalle":"descripcion"}', TRUE);
+
+INSERT INTO gps_registros (
+  importacion_id, unidad_id, jornada_id, fecha_hora, latitud, longitud,
+  velocidad_kmh, rumbo, odometro_km, estado, proveedor, raw_payload
+)
+VALUES
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 08:00:00', -12.0464000, -77.0428000,  0,   0, 18235.20, 'DETENIDO', 'GPSCONTROL', '{"status":"stopped"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 09:00:00', -13.1588000, -74.2236000, 45, 195, 18355.20, 'MOVIENDO', 'GPSCONTROL', '{"status":"moving"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 09:30:00', -13.3000000, -73.5000000, 95, 180, 18390.20, 'EXCESO_VELOCIDAD', 'GPSCONTROL', '{"status":"speeding"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 10:00:00', -13.5319000, -71.9675000, 62, 180, 18410.60, 'MOVIENDO', 'GPSCONTROL', '{"status":"moving"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 08:05:00', -12.0464000, -77.0428000, 12, 150, 24910.10, 'MOVIENDO', 'GLOBALGPS', '{"status":"moving","source":"xlsx"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 10:30:00', -13.6500000, -75.2000000, 70, 165, 25120.40, 'MOVIENDO', 'GLOBALGPS', '{"status":"moving","source":"xlsx"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 18:20:00', -16.4090000, -71.5370000, 0, 180, 25430.50, 'DETENIDO', 'GLOBALGPS', '{"status":"stopped","source":"xlsx"}');
+
+INSERT INTO gps_importacion_errores (
+  importacion_id, numero_fila, campo, valor_recibido, motivo_error, raw_payload
+)
+VALUES
+('f1110002-0000-0000-0000-000000000002', 4, 'latitud', 'N/A', 'Latitud no numerica', '{"vehicle_plate":"ABC-123","event_time":"2026-04-24 12:00:00","latitude":"N/A","longitude":"-74.990000"}'),
+('f1110002-0000-0000-0000-000000000002', 5, 'fecha_hora', '24/04/2026 25:90', 'Fecha u hora invalida', '{"vehicle_plate":"ABC-123","event_time":"24/04/2026 25:90","latitude":"-14.100000","longitude":"-74.500000"}');
+
+INSERT INTO gps_eventos (
+  unidad_id, jornada_id, tipo_evento, estado, fecha_hora_inicio, fecha_hora_fin,
+  velocidad_maxima, latitud, longitud, distancia_km, detalle
+)
+VALUES
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'DETENCION',         'DETENIDO',          '2026-04-26 08:00:00', '2026-04-26 08:05:00', 0,  -12.0464000, -77.0428000, 0.00, 'Unidad detenida antes de iniciar desplazamiento'),
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'MOVIMIENTO',        'MOVIENDO',          '2026-04-26 08:05:00', '2026-04-26 09:25:00', 62, -13.1588000, -74.2236000, 120.80, 'Desplazamiento normal'),
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'EXCESO_VELOCIDAD', 'EXCESO_VELOCIDAD', '2026-04-26 09:25:00', '2026-04-26 09:32:00', 95, -13.3000000, -73.5000000, 12.00, 'Velocidad mayor a 90 km/h');
+
+-- =========================================================
+-- COMBUSTIBLE
+-- =========================================================
+INSERT INTO combustible_registros (
+  id, jornada_id, unidad_id, conductor_id, contrato_id, tipo_comprobante, numero_comprobante,
+  galones, costo_total, kilometraje_actual, kilometraje_anterior, rendimiento_km_galon,
+  foto_comprobante_url, observaciones, latitud, longitud, estado, sincronizado, registrado_at
+)
+VALUES
+(
+  'f2110001-0000-0000-0000-000000000001',
+  'cccc0002-0000-0000-0000-000000000002',
+  'aaaa0002-0000-0000-0000-000000000002',
+  '33333333-3333-3333-3333-333333333333',
+  'bbbb0002-0000-0000-0000-000000000002',
+  'TICKET',
+  'TCK-0001',
+  18.50,
+  420.00,
+  18355.20,
+  18235.20,
+  6.49,
+  'https://example.com/combustible/tck-0001.jpg',
+  'Carga parcial en ruta',
+  -13.1588000,
+  -74.2236000,
+  'SINCRONIZADO',
+  TRUE,
+  '2026-04-26 09:12:00'
+);
+
+-- =========================================================
+-- MANTENIMIENTO
+-- =========================================================
+INSERT INTO camion_mantenimientos (
+  unidad_id, tipo, fecha_programada, fecha_ejecutada, kilometraje, costo, proveedor_taller, observaciones
+)
+VALUES
+('aaaa0003-0000-0000-0000-000000000003', 'PREVENTIVO', '2026-04-28', NULL, 32150.75, NULL, 'Taller Volvo Lima', 'Cambio de filtros y revisión general'),
+('aaaa0001-0000-0000-0000-000000000001', 'INSPECCION', '2026-03-10', '2026-03-10', 25000.00, 350.00, 'Taller Norte', 'Inspección rutinaria');
+
+-- =========================================================
+-- AUDITORIA / SESIONES
+-- =========================================================
+INSERT INTO auditoria_accesos (usuario_id, correo, rol, accion, resultado, ip_address, user_agent, dispositivo, detalle)
+VALUES
+('11111111-1111-1111-1111-111111111111', 'admin@nanutech.com',   'ADMIN',   'LOGIN',             'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Inicio de sesión correcto'),
+('33333333-3333-3333-3333-333333333333', 'chofer2@nanutech.com', 'CHOFER',  'INICIAR_JORNADA',   'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Android',        'Jornada iniciada desde panel chofer'),
+('55555555-5555-5555-5555-555555555555', 'gerencia@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
+
+INSERT INTO login_intentos (email, intentos_fallidos, ultimo_intento, bloqueado_hasta)
+VALUES ('invalido@nanutech.com', 2, NOW() - INTERVAL '2 hours', NULL);
+
+INSERT INTO password_reset_tokens (usuario_id, email, token, expira_at, usado)
+VALUES ('22222222-2222-2222-2222-222222222222', 'chofer1@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
+
+INSERT INTO sesiones_usuario (usuario_id, access_token_jti, refresh_token_jti, expira_at, ultimo_evento_at, estado)
+VALUES
+('11111111-1111-1111-1111-111111111111', 'JTI-ACCESS-ADMIN-001', 'JTI-REFRESH-ADMIN-001', NOW() + INTERVAL '8 hours', NOW(), 'ACTIVA'),
+('33333333-3333-3333-3333-333333333333', 'JTI-ACCESS-DRV-002',   'JTI-REFRESH-DRV-002',   NOW() + INTERVAL '8 hours', NOW(), 'ACTIVA');
+
+-- =========================================================
+-- HISTORIAL DE CONDUCTORES
+-- =========================================================
+INSERT INTO conductores_historial (conductor_id, accion, campo, valor_anterior, valor_nuevo, detalle, usuario_id, ip_address)
+VALUES
+('22222222-2222-2222-2222-222222222222', 'Actualización de estado operacional', 'estado_operacional', 'DISPONIBLE', 'DISPONIBLE', 'Validación administrativa', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('33333333-3333-3333-3333-333333333333', 'Asignación de jornada', 'current_shift_id', NULL, 'cccc0002-0000-0000-0000-000000000002', 'Conductor asignado a jornada activa', '11111111-1111-1111-1111-111111111111', '127.0.0.1');

--- a/db/seed/seed.sql
+++ b/db/seed/seed.sql
@@ -1,375 +1,411 @@
 -- migrate:up
 
 BEGIN;
-
--- ============================================
--- PASO 1: ELIMINAR DATOS EXISTENTES
--- ============================================
-
-DELETE FROM ubicaciones_jornada;
-DELETE FROM alertas_jornada;
-DELETE FROM jornadas;
-DELETE FROM contratos;
-DELETE FROM unidades;
-DELETE FROM usuarios;
-
--- ============================================
--- PASO 2: USUARIOS
--- ============================================
-
-INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni, activo, estado, ultimo_acceso)
+-- =========================================================
+-- USUARIOS
+-- =========================================================
+INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-  ('00000000-0000-0000-0000-000000000001',
-   '7438d4b8-0021-7065-dda7-7bbdfa75c929',
-   'admin@nanutech.com',
-   'Admin', 'Principal',
-   'ADMIN', '999888777', '12345678',
-   TRUE, 'ACTIVO',
-   NOW() - INTERVAL '1 hour'),
+('11111111-1111-1111-1111-111111111111', 'cognito-admin-001',   'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'cognito-driver-001',  'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-driver-002',  'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
+('44444444-4444-4444-4444-444444444444', 'cognito-driver-003',  'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
+('55555555-5555-5555-5555-555555555555', 'cognito-gerente-001', 'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
-  ('00000000-0000-0000-0000-000000000002',
-   'c4f84478-a051-707b-d0ee-ad4d95480a7c',
-   'chofer@nanutech.com',
-   'Carlos', 'Gomez',
-   'CHOFER', '999111222', '87654321',
-   TRUE, 'ACTIVO',
-   NOW() - INTERVAL '30 minutes'),
-
-  ('00000000-0000-0000-0000-000000000003',
-   'cognito-sub-chofer-002',
-   'chofer2@nanutech.com',
-   'Luis', 'Martinez',
-   'CHOFER', '999333444', '11223344',
-   TRUE, 'ACTIVO',
-   NOW() - INTERVAL '2 hours'),
-
-  ('00000000-0000-0000-0000-000000000004',
-   'cognito-sub-chofer-003',
-   'chofer3@nanutech.com',
-   'Pedro', 'Ramirez',
-   'CHOFER', '999555666', '22334455',
-   FALSE, 'INACTIVO',
-   NOW() - INTERVAL '30 days'),
-
-  ('00000000-0000-0000-0000-000000000005',
-   'cognito-sub-chofer-004',
-   'chofer4@nanutech.com',
-   'Jorge', 'Torres',
-   'CHOFER', '999777888', '33445566',
-   FALSE, 'BLOQUEADO',
-   NOW() - INTERVAL '60 days'),
-
-  ('00000000-0000-0000-0000-000000000006',
-   NULL,
-   'admin2@nanutech.com',
-   'Ana', 'Lopez',
-   'ADMIN', '999000111', '44556677',
-   TRUE, 'ACTIVO',
-   NULL);
-
--- ============================================
--- PASO 3: UNIDADES (CAMIONES)
--- ============================================
-
-INSERT INTO unidades (id, placa, marca, modelo, anio, capacidad_ton, estado, gps_habilitado, activo)
+-- =========================================================
+-- CONDUCTORES
+-- =========================================================
+INSERT INTO conductores (usuario_id, fecha_nacimiento, direccion, fecha_ingreso, estado_operacional, observaciones)
 VALUES
-  ('10000000-0000-0000-0000-000000000001',
-   'ABC-123', 'Mercedes Benz', 'Actros', 2022, 15.50, 'DISPONIBLE', TRUE, TRUE),
+('22222222-2222-2222-2222-222222222222', '1985-03-15', 'Av. Los Pinos 123, Lima',    '2020-01-15', 'DISPONIBLE', 'Conductor principal'),
+('33333333-3333-3333-3333-333333333333', '1988-07-22', 'Jr. Las Flores 456, Lima',   '2020-03-01', 'EN_RUTA',    'Conductor en jornada'),
+('44444444-4444-4444-4444-444444444444', '1982-11-10', 'Calle Los Alamos 789, Lima', '2019-06-15', 'DESCANSO',   'Conductor senior');
 
-  ('10000000-0000-0000-0000-000000000002',
-   'DEF-456', 'Volvo', 'FH16', 2023, 18.00, 'DISPONIBLE', TRUE, TRUE),
+INSERT INTO contactos_emergencia (conductor_id, nombre, telefono, parentesco, es_principal) VALUES
+('22222222-2222-2222-2222-222222222222', 'Maria Mendoza', '987111222', 'Esposa', TRUE),
+('33333333-3333-3333-3333-333333333333', 'Ana Ramirez',   '987222333', 'Hermana', TRUE),
+('44444444-4444-4444-4444-444444444444', 'Carmen Silva',  '987333444', 'Madre', TRUE);
 
-  ('10000000-0000-0000-0000-000000000003',
-   'GHI-789', 'Scania', 'R500', 2022, 16.50, 'EN_JORNADA', TRUE, TRUE),
+INSERT INTO licencias_conducir (conductor_id, numero_licencia, categoria, fecha_emision, fecha_vencimiento, autoridad_emisora, activa) VALUES
+('22222222-2222-2222-2222-222222222222', 'L45678901', 'A-III-b', '2022-01-10', '2027-01-10', 'MTC', TRUE),
+('33333333-3333-3333-3333-333333333333', 'L45678902', 'A-III-b', '2022-03-01', '2027-03-01', 'MTC', TRUE),
+('44444444-4444-4444-4444-444444444444', 'L45678903', 'A-III-c', '2021-08-15', '2026-08-15', 'MTC', TRUE);
 
-  ('10000000-0000-0000-0000-000000000004',
-   'JKL-012', 'Kenworth', 'T680', 2021, 20.00, 'EN_AUXILIO', TRUE, TRUE),
-
-  ('10000000-0000-0000-0000-000000000005',
-   'MNO-345', 'International', 'LT625', 2018, 12.00, 'INACTIVA', FALSE, FALSE);
-
-INSERT INTO unidades (id, placa, marca, modelo, anio, capacidad_ton, estado, gps_habilitado, activo)
+-- =========================================================
+-- GPS
+-- =========================================================
+INSERT INTO gps_dispositivos (id, codigo_equipo, proveedor, imei, numero_sim, activo)
 VALUES
-  ('20000000-0000-0000-0000-000000000001',
-   'BCD-111', 'Volvo', 'FH', 2021, 16.00, 'DISPONIBLE', TRUE, TRUE),
+('90000000-0000-0000-0000-000000000001', 'GPS-2026-0001', 'GPSCONTROL', '359111111111111', '51990000001', TRUE),
+('90000000-0000-0000-0000-000000000002', 'GPS-2026-0002', 'GPSCONTROL', '359222222222222', '51990000002', TRUE),
+('90000000-0000-0000-0000-000000000003', 'GPS-2026-0003', 'GLOBALGPS',  '359333333333333', '51990000003', TRUE);
 
-  ('20000000-0000-0000-0000-000000000002',
-   'CDE-222', 'Scania', 'R450', 2022, 17.50, 'DISPONIBLE', TRUE, TRUE),
-
-  ('20000000-0000-0000-0000-000000000003',
-   'DEF-333', 'Mercedes Benz', 'Actros 2645', 2023, 18.20, 'DISPONIBLE', TRUE, TRUE),
-
-  ('20000000-0000-0000-0000-000000000004',
-   'EFG-444', 'Kenworth', 'T800', 2020, 19.00, 'DISPONIBLE', FALSE, TRUE),
-
-  ('20000000-0000-0000-0000-000000000005',
-   'FGH-555', 'International', 'RH', 2019, 14.80, 'DISPONIBLE', TRUE, TRUE),
-
-  ('20000000-0000-0000-0000-000000000006',
-   'GHI-666', 'MAN', 'TGX', 2022, 20.00, 'DISPONIBLE', TRUE, TRUE);
-
--- ============================================
--- PASO 4: CONTRATOS
--- ============================================
-
-INSERT INTO contratos (id, codigo, cliente, descripcion, fecha_inicio, fecha_fin, tarifa, moneda, estado, activo)
+-- =========================================================
+-- UNIDADES (triggers crean camiones automáticamente)
+-- =========================================================
+INSERT INTO unidades (
+  id, placa, marca, modelo, anio, capacidad_ton, estado, gps_habilitado, activo,
+  vin, color, tipo_combustible, fecha_registro,
+  ultima_fecha_mantenimiento, proxima_fecha_mantenimiento,
+  kilometraje_actual, gps_device_id, notas
+)
 VALUES
-  ('20000000-0000-0000-0000-000000000001',
-   'CONT-001', 'Empresa A SAC',
-   'Transporte de minerales',
-   '2025-01-01', '2026-12-31',      
-   5000.00, 'PEN', 'VIGENTE', TRUE),
+('aaaa0001-0000-0000-0000-000000000001', 'ABC-123', 'Volvo',         'FH16',   2020, 20.00, 'DISPONIBLE',    TRUE, TRUE, 'VINVOLVO0001', 'Blanco', 'DIESEL', '2025-01-15', '2026-03-10', '2026-06-10', 25430.50, '90000000-0000-0000-0000-000000000001', 'Unidad operativa'),
+('aaaa0002-0000-0000-0000-000000000002', 'DEF-456', 'Scania',        'R450',   2021, 18.00, 'EN_JORNADA',    TRUE, TRUE, 'VINSCANIA02',  'Rojo',   'DIESEL', '2025-02-20', '2026-03-18', '2026-06-18', 18235.20, '90000000-0000-0000-0000-000000000002', 'Unidad en jornada'),
+('aaaa0003-0000-0000-0000-000000000003', 'GHI-789', 'Mercedes-Benz', 'Actros', 2019, 22.00, 'MANTENIMIENTO', TRUE, TRUE, 'VINMERCED03',  'Azul',   'DIESEL', '2025-03-10', '2026-04-01', '2026-05-15', 32150.75, '90000000-0000-0000-0000-000000000003', 'Unidad en mantenimiento');
 
-  ('20000000-0000-0000-0000-000000000002',
-   'CONT-002', 'Empresa B EIRL',
-   'Transporte de insumos',
-   '2025-01-01', '2026-12-31',       
-   3500.00, 'PEN', 'VIGENTE', TRUE),
+-- =========================================================
+-- ASIGNACIONES
+-- =========================================================
+INSERT INTO asignaciones_conductor_unidad (conductor_id, unidad_id, fecha_inicio, estado, creado_por, observaciones) VALUES
+('22222222-2222-2222-2222-222222222222', 'aaaa0001-0000-0000-0000-000000000001', '2026-04-20 08:00:00', 'ACTIVA', '11111111-1111-1111-1111-111111111111', 'Asignación principal'),
+('33333333-3333-3333-3333-333333333333', 'aaaa0002-0000-0000-0000-000000000002', '2026-04-20 08:00:00', 'ACTIVA', '11111111-1111-1111-1111-111111111111', 'Asignación principal');
 
-  ('20000000-0000-0000-0000-000000000003',
-   'CONT-003', 'Empresa C SRL',
-   'Transporte de productos terminados',
-   '2025-02-01', '2026-12-31',      
-   4200.00, 'PEN', 'VIGENTE', TRUE),
+-- =========================================================
+-- CONTRATOS
+-- =========================================================
+INSERT INTO contratos (
+  id, codigo, cliente, ruc, descripcion, tipo_servicio, fecha_inicio, fecha_fin,
+  tarifa, moneda, estado, activo, updated_by
+)
+VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'CONT-2026-001', 'Minera del Sur',   '20123456789', 'Transporte de carga minera',   'POR_VIAJE', '2026-01-01', '2026-12-31', 15000.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111'),
+('bbbb0002-0000-0000-0000-000000000002', 'CONT-2026-002', 'Logistica Andina', '20987654321', 'Distribución interprovincial', 'POR_HORA',  '2026-02-01', '2026-10-31',  9800.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111'),
+('bbbb0003-0000-0000-0000-000000000003', 'CONT-2026-003', 'Agroexport Norte', '20456789123', 'Transporte por tonelada', 'POR_TONELADA', '2026-03-01', '2026-11-30', 12500.00, 'PEN', 'VIGENTE', TRUE, '11111111-1111-1111-1111-111111111111');
 
-  ('20000000-0000-0000-0000-000000000004',
-   'CONT-004', 'Empresa D SA',
-   'Transporte internacional',
-   '2023-01-01', '2023-12-31',
-   8000.00, 'USD', 'VENCIDO', TRUE), 
+INSERT INTO contrato_rutas (contrato_id, origen, destino, distancia_estimada_km) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'Lima', 'Arequipa', 520.00),
+('bbbb0002-0000-0000-0000-000000000002', 'Lima', 'Ica', 300.00),
+('bbbb0003-0000-0000-0000-000000000003', 'Trujillo', 'Piura', 420.00);
 
-  ('20000000-0000-0000-0000-000000000005',
-   'CONT-005', 'Empresa E SAC',
-   'Contrato marco sin fecha fin definida',
-   '2024-06-01', NULL,
-   6000.00, 'PEN', 'SUSPENDIDO', TRUE);
+INSERT INTO contrato_tarifas (contrato_id, tarifa_base, tarifa_por_km, tarifa_por_hora, tarifa_por_tonelada, tarifa_espera, total_referencial) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 15000.00, 0, 0, 0, 0, 15000.00),
+('bbbb0002-0000-0000-0000-000000000002', 5000.00, 0, 450.00, 0, 100.00, 9800.00),
+('bbbb0003-0000-0000-0000-000000000003', 3500.00, 0, 0, 180.00, 150.00, 12500.00);
 
--- ============================================
--- PASO 5: JORNADAS
--- ============================================
+INSERT INTO contrato_unidades (contrato_id, unidad_id, assigned_by, activo) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '11111111-1111-1111-1111-111111111111', TRUE),
+('bbbb0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', '11111111-1111-1111-1111-111111111111', TRUE),
+('bbbb0003-0000-0000-0000-000000000003', 'aaaa0003-0000-0000-0000-000000000003', '11111111-1111-1111-1111-111111111111', TRUE);
 
--- Jornada COMPLETADA: chofer1 + ABC-123 + CONT-001
-INSERT INTO jornadas (id, conductor_id, unidad_id, contrato_id, creado_por,
-                      fecha_jornada, hora_inicio, hora_fin,
-                      origen, destino, km_recorridos, observaciones, estado)
-SELECT
-  '30000000-0000-0000-0000-000000000001',
-  '00000000-0000-0000-0000-000000000002',  -- chofer1 Carlos Gomez
-  '10000000-0000-0000-0000-000000000001',  -- ABC-123 Mercedes Benz Actros
-  '20000000-0000-0000-0000-000000000001',  -- CONT-001
-  '00000000-0000-0000-0000-000000000001',  -- admin
-  CURRENT_DATE,
-  NOW() - INTERVAL '8 hours',
-  NOW() - INTERVAL '1 hour',
-  'Lima', 'Callao',
-  120.50,
-  'Jornada completada sin incidentes.',
+INSERT INTO contratos_historial (contrato_id, accion, campo, valor_anterior, valor_nuevo, detalle, usuario_id, ip_address) VALUES
+('bbbb0001-0000-0000-0000-000000000001', 'Creación de contrato', NULL, NULL, NULL, 'Contrato registrado en el sistema', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('bbbb0002-0000-0000-0000-000000000002', 'Asignación de unidad', 'unidad', NULL, 'DEF-456', 'Se asignó unidad al contrato', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('bbbb0003-0000-0000-0000-000000000003', 'Creación de tarifa', 'tarifa_por_tonelada', NULL, '180.00', 'Contrato configurado por tonelada', '11111111-1111-1111-1111-111111111111', '127.0.0.1');
+
+-- =========================================================
+-- JORNADAS
+-- =========================================================
+INSERT INTO jornadas (
+  id, codigo, conductor_id, unidad_id, contrato_id, creado_por,
+  fecha_jornada, hora_inicio_programada, hora_fin_programada,
+  hora_inicio, hora_fin, origen, destino,
+  km_estimados, km_recorridos, tipo_carga, peso_carga_ton,
+  observaciones, observacion_admin, estado
+)
+VALUES
+(
+  'cccc0001-0000-0000-0000-000000000001',
+  'JOR-2026-0001',
+  '22222222-2222-2222-2222-222222222222',
+  'aaaa0001-0000-0000-0000-000000000001',
+  'bbbb0001-0000-0000-0000-000000000001',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-24',
+  '2026-04-24 08:00:00',
+  '2026-04-24 18:00:00',
+  '2026-04-24 08:05:00',
+  '2026-04-24 18:20:00',
+  'Lima',
+  'Arequipa',
+  520.00,
+  525.40,
+  'Mineral concentrado',
+  18.50,
+  'Jornada completada sin incidencias mayores',
+  'Cumplimiento correcto',
   'COMPLETADA'
-WHERE EXISTS (SELECT 1 FROM contratos WHERE id = '20000000-0000-0000-0000-000000000001');
-
--- Jornada EN_PROCESO: chofer2 + GHI-789 + CONT-002
-INSERT INTO jornadas (id, conductor_id, unidad_id, contrato_id, creado_por,
-                      fecha_jornada, hora_inicio, hora_fin,
-                      origen, destino, km_recorridos, observaciones, estado)
-SELECT
-  '30000000-0000-0000-0000-000000000002',
-  '00000000-0000-0000-0000-000000000003',  -- chofer2 Luis Martinez
-  '10000000-0000-0000-0000-000000000003',  -- GHI-789 Scania R500
-  '20000000-0000-0000-0000-000000000002',  -- CONT-002
-  '00000000-0000-0000-0000-000000000001',  -- admin
-  CURRENT_DATE,
-  NOW() - INTERVAL '2 hours',
+),
+(
+  'cccc0002-0000-0000-0000-000000000002',
+  'JOR-2026-0002',
+  '33333333-3333-3333-3333-333333333333',
+  'aaaa0002-0000-0000-0000-000000000002',
+  'bbbb0002-0000-0000-0000-000000000002',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-26',
+  '2026-04-26 08:00:00',
+  '2026-04-26 16:00:00',
+  '2026-04-26 08:00:00',
   NULL,
-  'Callao', 'Huachipa',
-  45.00,
+  'Lima',
+  'Ica',
+  300.00,
+  120.80,
+  'Paquetería',
+  8.00,
+  'Jornada en curso',
   NULL,
   'EN_PROCESO'
-WHERE EXISTS (SELECT 1 FROM contratos WHERE id = '20000000-0000-0000-0000-000000000002');
+),
+(
+  'cccc0003-0000-0000-0000-000000000003',
+  'JOR-2026-0003',
+  '22222222-2222-2222-2222-222222222222',
+  'aaaa0001-0000-0000-0000-000000000001',
+  'bbbb0001-0000-0000-0000-000000000001',
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-27',
+  '2026-04-27 08:00:00',
+  '2026-04-27 18:00:00',
+  NULL,
+  NULL,
+  'Lima',
+  'Arequipa',
+  520.00,
+  0,
+  'Mineral concentrado',
+  18.50,
+  NULL,
+  NULL,
+  'PENDIENTE'
+);
 
--- Jornada REGISTRADA: chofer1 + DEF-456 + CONT-003
--- FIX: conductor cambiado a chofer3 Pedro Ramirez para no violar uq_jornada_activa_chofer
-INSERT INTO jornadas (id, conductor_id, unidad_id, contrato_id, creado_por,
-                      fecha_jornada, hora_inicio, hora_fin,
-                      origen, destino, km_recorridos, observaciones, estado)
-SELECT
-  '30000000-0000-0000-0000-000000000003',
-  '00000000-0000-0000-0000-000000000004',  -- chofer3 Pedro Ramirez (FIX)
-  '10000000-0000-0000-0000-000000000002',  -- DEF-456 Volvo FH16
-  '20000000-0000-0000-0000-000000000003',  -- CONT-003
-  '00000000-0000-0000-0000-000000000001',  -- admin
-  CURRENT_DATE + 1,
-  NULL, NULL,
-  'Lima', 'Ica',
-  0.00,
-  'Llevar documentación especial.',
-  'REGISTRADA'
-WHERE EXISTS (SELECT 1 FROM contratos WHERE id = '20000000-0000-0000-0000-000000000003');
+UPDATE conductores
+SET current_shift_id = 'cccc0002-0000-0000-0000-000000000002'
+WHERE usuario_id = '33333333-3333-3333-3333-333333333333';
 
--- Jornada CANCELADA: chofer1 + ABC-123 + CONT-001
-INSERT INTO jornadas (id, conductor_id, unidad_id, contrato_id, creado_por,
-                      fecha_jornada, hora_inicio, hora_fin,
-                      origen, destino, km_recorridos, observaciones, estado)
-SELECT
-  '30000000-0000-0000-0000-000000000004',
-  '00000000-0000-0000-0000-000000000002',  -- chofer1 Carlos Gomez
-  '10000000-0000-0000-0000-000000000001',  -- ABC-123 Mercedes Benz Actros
-  '20000000-0000-0000-0000-000000000001',  -- CONT-001
-  '00000000-0000-0000-0000-000000000001',  -- admin
-  CURRENT_DATE - 1,
-  NULL, NULL,
-  'Lima', 'Arequipa',
-  0.00,
-  'Cancelada por falla mecánica antes de iniciar.',
-  'CANCELADA'
-WHERE EXISTS (SELECT 1 FROM contratos WHERE id = '20000000-0000-0000-0000-000000000001');
-
--- ============================================
--- PASO 6: ALERTAS
--- ============================================
-
--- Alerta PANICO no atendida (jornada EN_PROCESO)
-INSERT INTO alertas_jornada (id, jornada_id, tipo, detalle, latitud, longitud, fecha_hora, atendida)
-SELECT
-  '40000000-0000-0000-0000-000000000001',
-  '30000000-0000-0000-0000-000000000002',
-  'PANICO',
-  'Conductor presionó botón de pánico. Posible asalto.',
-  -12.043333, -77.028333,
-  NOW() - INTERVAL '1 hour',
-  FALSE
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000002');
-
--- Alerta PANICO atendida (jornada COMPLETADA)
-INSERT INTO alertas_jornada (id, jornada_id, tipo, detalle, latitud, longitud, fecha_hora,
-                              atendida, atendida_at, atendida_por)
-SELECT
-  '40000000-0000-0000-0000-000000000002',
-  '30000000-0000-0000-0000-000000000001',
-  'PANICO',
-  'Falsa alarma confirmada por el conductor.',
-  -12.050000, -77.030000,
-  NOW() - INTERVAL '6 hours',
-  TRUE,
-  NOW() - INTERVAL '5 hours',
-  '00000000-0000-0000-0000-000000000001'
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000001');
-
--- Alerta AUXILIO_MECANICO no atendida (jornada EN_PROCESO)
-INSERT INTO alertas_jornada (id, jornada_id, tipo, detalle, latitud, longitud, fecha_hora, atendida)
-SELECT
-  '40000000-0000-0000-0000-000000000003',
-  '30000000-0000-0000-0000-000000000002',
+-- =========================================================
+-- ALERTAS
+-- =========================================================
+INSERT INTO alertas_jornada (
+  id, codigo, jornada_id, tipo, estado, severidad, detalle,
+  tipo_falla_mecanica, latitud, longitud, direccion, fecha_hora,
+  atendida, atendida_por, atendida_at, detalle_resolucion,
+  servicio_tecnico_realizado, telefono_contactado, bloqueo_sos_activo
+)
+VALUES
+(
+  'dddd0001-0000-0000-0000-000000000001',
+  'ALT-2026-0001',
+  'cccc0002-0000-0000-0000-000000000002',
   'AUXILIO_MECANICO',
-  'Pinchazo de llanta en carretera central km 45.',
-  -12.000000, -76.900000,
-  NOW() - INTERVAL '30 minutes',
+  'ACTIVA',
+  'ALTA',
+  'Falla mecánica reportada por el conductor',
+  'Sobrecalentamiento',
+  -13.1588000,
+  -74.2236000,
+  'Km 250 Panamericana Sur',
+  '2026-04-26 09:10:00',
+  FALSE,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   FALSE
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000002');
-
--- Alerta AUXILIO_MECANICO atendida (jornada COMPLETADA)
-INSERT INTO alertas_jornada (id, jornada_id, tipo, detalle, latitud, longitud, fecha_hora,
-                              atendida, atendida_at, atendida_por)
-SELECT
-  '40000000-0000-0000-0000-000000000004',
-  '30000000-0000-0000-0000-000000000001',
-  'AUXILIO_MECANICO',
-  'Falla en batería, grúa enviada y resuelta.',
-  -12.060000, -77.010000,
-  NOW() - INTERVAL '7 hours',
+),
+(
+  'dddd0002-0000-0000-0000-000000000002',
+  'ALT-2026-0002',
+  'cccc0001-0000-0000-0000-000000000001',
+  'PANICO',
+  'RESUELTA',
+  'CRITICA',
+  'Botón SOS activado por 3 segundos',
+  NULL,
+  -16.4090000,
+  -71.5370000,
+  'Ingreso a Arequipa',
+  '2026-04-24 17:10:00',
   TRUE,
-  NOW() - INTERVAL '6 hours',
-  '00000000-0000-0000-0000-000000000001'
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000001');
+  '11111111-1111-1111-1111-111111111111',
+  '2026-04-24 17:20:00',
+  'Alerta validada y cerrada por central',
+  'No aplica',
+  '999111222',
+  TRUE
+);
 
--- ============================================
--- PASO 7: UBICACIONES
--- ============================================
+INSERT INTO alertas_historial (alerta_id, accion, detalle, usuario_id, created_at) VALUES
+('dddd0001-0000-0000-0000-000000000001', 'Registro de alerta', 'Se recibió auxilio mecánico en ruta', '33333333-3333-3333-3333-333333333333', '2026-04-26 09:10:00'),
+('dddd0002-0000-0000-0000-000000000002', 'Cierre de alerta', 'Alerta resuelta por central', '11111111-1111-1111-1111-111111111111', '2026-04-24 17:20:00');
 
--- Registro INICIO (jornada COMPLETADA)
-INSERT INTO ubicaciones_jornada (id, jornada_id, latitud, longitud, fecha_hora, tipo_registro, velocidad_kmh)
-SELECT
-  '50000000-0000-0000-0000-000000000001',
-  '30000000-0000-0000-0000-000000000001',
-  -12.046374, -77.042793,
-  NOW() - INTERVAL '8 hours',
-  'INICIO', 0.00
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000001');
+-- =========================================================
+-- UBICACIONES / GPS
+-- =========================================================
+INSERT INTO ubicaciones_jornada (
+  id, jornada_id, unidad_id, latitud, longitud, direccion,
+  fecha_hora, tipo_registro, velocidad_kmh, rumbo, odometro_km, proveedor
+)
+VALUES
+('eeee0001-0000-0000-0000-000000000001', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -12.0464000, -77.0428000, 'Lima Centro',              '2026-04-26 08:00:00', 'INICIO',   0,   0, 18235.20, 'GPSCONTROL'),
+('eeee0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -13.1588000, -74.2236000, 'Km 250 Panamericana Sur', '2026-04-26 09:10:00', 'ALERTA',  45, 195, 18355.20, 'GPSCONTROL'),
+('eeee0003-0000-0000-0000-000000000003', 'cccc0002-0000-0000-0000-000000000002', 'aaaa0002-0000-0000-0000-000000000002', -13.5319000, -71.9675000, 'Tramo intermedio',         '2026-04-26 10:00:00', 'TRACKING',62, 180, 18410.60, 'GPSCONTROL'),
+('eeee0004-0000-0000-0000-000000000004', 'cccc0001-0000-0000-0000-000000000001', 'aaaa0001-0000-0000-0000-000000000001', -16.4090000, -71.5370000, 'Ingreso a Arequipa',       '2026-04-24 18:20:00', 'FIN',      0,   0, 25430.50, 'GPSCONTROL');
 
--- Registros TRACKING (jornada COMPLETADA)
-INSERT INTO ubicaciones_jornada (id, jornada_id, latitud, longitud, fecha_hora, tipo_registro, velocidad_kmh)
-SELECT
-  gen_random_uuid(),
-  '30000000-0000-0000-0000-000000000001',
-  -12.046374 + (gs * 0.005),
-  -77.042793 + (gs * 0.003),
-  NOW() - INTERVAL '8 hours' + (gs * INTERVAL '30 minutes'),
-  'TRACKING',
-  55 + (random() * 30)
-FROM generate_series(1, 8) AS gs
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000001');
+INSERT INTO gps_importaciones (
+  id, proveedor, nombre_archivo, cargado_por, total_registros, registros_validos,
+  registros_invalidos, estado, observaciones, processed_at
+)
+VALUES
+(
+  'f1110001-0000-0000-0000-000000000001',
+  'GPSCONTROL',
+  'tracking_gps_2026-04-26.csv',
+  '11111111-1111-1111-1111-111111111111',
+  4, 4, 0, 'PROCESADA',
+  'Archivo cargado correctamente',
+  '2026-04-26 10:05:00'
+),
+(
+  'f1110002-0000-0000-0000-000000000002',
+  'GLOBALGPS',
+  'globalgps_ruta_arequipa_2026-04-24.xlsx',
+  '11111111-1111-1111-1111-111111111111',
+  5, 3, 2, 'PROCESADA_CON_ERRORES',
+  'Archivo procesado con filas observadas',
+  '2026-04-24 19:05:00'
+);
 
--- Registro ALERTA (jornada COMPLETADA)
-INSERT INTO ubicaciones_jornada (id, jornada_id, latitud, longitud, fecha_hora, tipo_registro, velocidad_kmh)
-SELECT
-  '50000000-0000-0000-0000-000000000002',
-  '30000000-0000-0000-0000-000000000001',
-  -12.050000, -77.030000,
-  NOW() - INTERVAL '6 hours',
-  'ALERTA', 0.00
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000001');
+INSERT INTO gps_proveedor_formatos (proveedor, nombre_formato, mapeo_columnas, activo)
+VALUES
+('GPSCONTROL', 'csv_tracking_v1', '{"unidad":"placa","fecha_hora":"fecha","latitud":"lat","longitud":"lon","velocidad_kmh":"velocidad","rumbo":"rumbo","odometro_km":"odometro"}', TRUE),
+('GLOBALGPS', 'xlsx_tracking_v2', '{"unidad":"vehicle_plate","fecha_hora":"event_time","latitud":"latitude","longitud":"longitude","velocidad_kmh":"speed","rumbo":"heading","odometro_km":"mileage"}', TRUE),
+('GPSCONTROL', 'csv_alertas_v1', '{"unidad":"placa","fecha_hora":"fecha_alerta","latitud":"lat","longitud":"lon","tipo_evento":"evento","detalle":"descripcion"}', TRUE);
 
--- Registro FIN (jornada COMPLETADA)
-INSERT INTO ubicaciones_jornada (id, jornada_id, latitud, longitud, fecha_hora, tipo_registro, velocidad_kmh)
-SELECT
-  '50000000-0000-0000-0000-000000000003',
-  '30000000-0000-0000-0000-000000000001',
-  -11.990000, -77.120000,
-  NOW() - INTERVAL '1 hour',
-  'FIN', 0.00
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000001');
+INSERT INTO gps_registros (
+  importacion_id, unidad_id, jornada_id, fecha_hora, latitud, longitud,
+  velocidad_kmh, rumbo, odometro_km, estado, proveedor, raw_payload
+)
+VALUES
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 08:00:00', -12.0464000, -77.0428000,  0,   0, 18235.20, 'DETENIDO', 'GPSCONTROL', '{"status":"stopped"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 09:00:00', -13.1588000, -74.2236000, 45, 195, 18355.20, 'MOVIENDO', 'GPSCONTROL', '{"status":"moving"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 09:30:00', -13.3000000, -73.5000000, 95, 180, 18390.20, 'EXCESO_VELOCIDAD', 'GPSCONTROL', '{"status":"speeding"}'),
+('f1110001-0000-0000-0000-000000000001', 'aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', '2026-04-26 10:00:00', -13.5319000, -71.9675000, 62, 180, 18410.60, 'MOVIENDO', 'GPSCONTROL', '{"status":"moving"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 08:05:00', -12.0464000, -77.0428000, 12, 150, 24910.10, 'MOVIENDO', 'GLOBALGPS', '{"status":"moving","source":"xlsx"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 10:30:00', -13.6500000, -75.2000000, 70, 165, 25120.40, 'MOVIENDO', 'GLOBALGPS', '{"status":"moving","source":"xlsx"}'),
+('f1110002-0000-0000-0000-000000000002', 'aaaa0001-0000-0000-0000-000000000001', 'cccc0001-0000-0000-0000-000000000001', '2026-04-24 18:20:00', -16.4090000, -71.5370000, 0, 180, 25430.50, 'DETENIDO', 'GLOBALGPS', '{"status":"stopped","source":"xlsx"}');
 
--- Registro INICIO (jornada EN_PROCESO)
-INSERT INTO ubicaciones_jornada (id, jornada_id, latitud, longitud, fecha_hora, tipo_registro, velocidad_kmh)
-SELECT
-  '50000000-0000-0000-0000-000000000004',
-  '30000000-0000-0000-0000-000000000002',
-  -12.055000, -77.085000,
-  NOW() - INTERVAL '2 hours',
-  'INICIO', 0.00
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000002');
+INSERT INTO gps_importacion_errores (
+  importacion_id, numero_fila, campo, valor_recibido, motivo_error, raw_payload
+)
+VALUES
+('f1110002-0000-0000-0000-000000000002', 4, 'latitud', 'N/A', 'Latitud no numerica', '{"vehicle_plate":"ABC-123","event_time":"2026-04-24 12:00:00","latitude":"N/A","longitude":"-74.990000"}'),
+('f1110002-0000-0000-0000-000000000002', 5, 'fecha_hora', '24/04/2026 25:90', 'Fecha u hora invalida', '{"vehicle_plate":"ABC-123","event_time":"24/04/2026 25:90","latitude":"-14.100000","longitude":"-74.500000"}');
 
--- Registros TRACKING en curso (jornada EN_PROCESO)
-INSERT INTO ubicaciones_jornada (id, jornada_id, latitud, longitud, fecha_hora, tipo_registro, velocidad_kmh)
-SELECT
-  gen_random_uuid(),
-  '30000000-0000-0000-0000-000000000002',
-  -12.055000 + (gs * 0.004),
-  -77.085000 + (gs * 0.002),
-  NOW() - INTERVAL '2 hours' + (gs * INTERVAL '20 minutes'),
-  'TRACKING',
-  40 + (random() * 50)
-FROM generate_series(1, 5) AS gs
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000002');
+INSERT INTO gps_eventos (
+  unidad_id, jornada_id, tipo_evento, estado, fecha_hora_inicio, fecha_hora_fin,
+  velocidad_maxima, latitud, longitud, distancia_km, detalle
+)
+VALUES
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'DETENCION',         'DETENIDO',          '2026-04-26 08:00:00', '2026-04-26 08:05:00', 0,  -12.0464000, -77.0428000, 0.00, 'Unidad detenida antes de iniciar desplazamiento'),
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'MOVIMIENTO',        'MOVIENDO',          '2026-04-26 08:05:00', '2026-04-26 09:25:00', 62, -13.1588000, -74.2236000, 120.80, 'Desplazamiento normal'),
+('aaaa0002-0000-0000-0000-000000000002', 'cccc0002-0000-0000-0000-000000000002', 'EXCESO_VELOCIDAD', 'EXCESO_VELOCIDAD', '2026-04-26 09:25:00', '2026-04-26 09:32:00', 95, -13.3000000, -73.5000000, 12.00, 'Velocidad mayor a 90 km/h');
 
--- Registro ALERTA (jornada EN_PROCESO)
-INSERT INTO ubicaciones_jornada (id, jornada_id, latitud, longitud, fecha_hora, tipo_registro, velocidad_kmh)
-SELECT
-  '50000000-0000-0000-0000-000000000005',
-  '30000000-0000-0000-0000-000000000002',
-  -12.043333, -77.028333,
-  NOW() - INTERVAL '1 hour',
-  'ALERTA', 0.00
-WHERE EXISTS (SELECT 1 FROM jornadas WHERE id = '30000000-0000-0000-0000-000000000002');
+-- =========================================================
+-- COMBUSTIBLE
+-- =========================================================
+INSERT INTO combustible_registros (
+  id, jornada_id, unidad_id, conductor_id, contrato_id, tipo_comprobante, numero_comprobante,
+  galones, costo_total, kilometraje_actual, kilometraje_anterior, rendimiento_km_galon,
+  foto_comprobante_url, observaciones, latitud, longitud, estado, sincronizado, registrado_at
+)
+VALUES
+(
+  'f2110001-0000-0000-0000-000000000001',
+  'cccc0002-0000-0000-0000-000000000002',
+  'aaaa0002-0000-0000-0000-000000000002',
+  '33333333-3333-3333-3333-333333333333',
+  'bbbb0002-0000-0000-0000-000000000002',
+  'TICKET',
+  'TCK-0001',
+  18.50,
+  420.00,
+  18355.20,
+  18235.20,
+  6.49,
+  'https://example.com/combustible/tck-0001.jpg',
+  'Carga parcial en ruta',
+  -13.1588000,
+  -74.2236000,
+  'SINCRONIZADO',
+  TRUE,
+  '2026-04-26 09:12:00'
+);
+
+-- =========================================================
+-- MANTENIMIENTO
+-- =========================================================
+INSERT INTO camion_mantenimientos (
+  unidad_id, tipo, fecha_programada, fecha_ejecutada, kilometraje, costo, proveedor_taller, observaciones
+)
+VALUES
+('aaaa0003-0000-0000-0000-000000000003', 'PREVENTIVO', '2026-04-28', NULL, 32150.75, NULL, 'Taller Volvo Lima', 'Cambio de filtros y revisión general'),
+('aaaa0001-0000-0000-0000-000000000001', 'INSPECCION', '2026-03-10', '2026-03-10', 25000.00, 350.00, 'Taller Norte', 'Inspección rutinaria');
+
+-- =========================================================
+-- AUDITORIA / SESIONES
+-- =========================================================
+INSERT INTO auditoria_accesos (usuario_id, correo, rol, accion, resultado, ip_address, user_agent, dispositivo, detalle)
+VALUES
+('11111111-1111-1111-1111-111111111111', 'admin@nanutech.com',   'ADMIN',   'LOGIN',             'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Inicio de sesión correcto'),
+('33333333-3333-3333-3333-333333333333', 'chofer2@nanutech.com', 'CHOFER',  'INICIAR_JORNADA',   'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Android',        'Jornada iniciada desde panel chofer'),
+('55555555-5555-5555-5555-555555555555', 'gerencia@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
+
+INSERT INTO login_intentos (email, intentos_fallidos, ultimo_intento, bloqueado_hasta)
+VALUES ('invalido@nanutech.com', 2, NOW() - INTERVAL '2 hours', NULL);
+
+INSERT INTO password_reset_tokens (usuario_id, email, token, expira_at, usado)
+VALUES ('22222222-2222-2222-2222-222222222222', 'chofer1@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
+
+INSERT INTO sesiones_usuario (usuario_id, access_token_jti, refresh_token_jti, expira_at, ultimo_evento_at, estado)
+VALUES
+('11111111-1111-1111-1111-111111111111', 'JTI-ACCESS-ADMIN-001', 'JTI-REFRESH-ADMIN-001', NOW() + INTERVAL '8 hours', NOW(), 'ACTIVA'),
+('33333333-3333-3333-3333-333333333333', 'JTI-ACCESS-DRV-002',   'JTI-REFRESH-DRV-002',   NOW() + INTERVAL '8 hours', NOW(), 'ACTIVA');
+
+-- =========================================================
+-- HISTORIAL DE CONDUCTORES
+-- =========================================================
+INSERT INTO conductores_historial (conductor_id, accion, campo, valor_anterior, valor_nuevo, detalle, usuario_id, ip_address)
+VALUES
+('22222222-2222-2222-2222-222222222222', 'Actualización de estado operacional', 'estado_operacional', 'DISPONIBLE', 'DISPONIBLE', 'Validación administrativa', '11111111-1111-1111-1111-111111111111', '127.0.0.1'),
+('33333333-3333-3333-3333-333333333333', 'Asignación de jornada', 'current_shift_id', NULL, 'cccc0002-0000-0000-0000-000000000002', 'Conductor asignado a jornada activa', '11111111-1111-1111-1111-111111111111', '127.0.0.1');
 
 COMMIT;
 
 -- migrate:down
 
 BEGIN;
+DELETE FROM conductores_historial;
+DELETE FROM sesiones_usuario;
+DELETE FROM password_reset_tokens;
+DELETE FROM login_intentos;
+DELETE FROM auditoria_accesos;
+DELETE FROM combustible_registros;
+DELETE FROM gps_eventos;
+DELETE FROM gps_registros;
+DELETE FROM gps_importacion_errores;
+DELETE FROM gps_proveedor_formatos;
+DELETE FROM gps_importaciones;
 DELETE FROM ubicaciones_jornada;
+DELETE FROM alertas_historial;
 DELETE FROM alertas_jornada;
+UPDATE conductores SET current_shift_id = NULL;
 DELETE FROM jornadas;
+DELETE FROM contratos_historial;
+DELETE FROM contrato_unidades;
+DELETE FROM contrato_tarifas;
+DELETE FROM contrato_rutas;
 DELETE FROM contratos;
+DELETE FROM asignaciones_conductor_unidad;
+DELETE FROM camion_mantenimientos;
+DELETE FROM camiones;
 DELETE FROM unidades;
+DELETE FROM gps_dispositivos;
+DELETE FROM licencias_conducir;
+DELETE FROM contactos_emergencia;
+DELETE FROM conductores;
 DELETE FROM usuarios;
 COMMIT;

--- a/db/seed/seed.sql
+++ b/db/seed/seed.sql
@@ -6,11 +6,11 @@ BEGIN;
 -- =========================================================
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', 'cognito-admin-001',   'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'cognito-driver-001',  'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
-('33333333-3333-3333-3333-333333333333', 'cognito-driver-002',  'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
-('44444444-4444-4444-4444-444444444444', 'cognito-driver-003',  'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
-('55555555-5555-5555-5555-555555555555', 'cognito-gerente-001', 'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
+('11111111-1111-1111-1111-111111111111', '7438d4b8-0021-7065-dda7-7bbdfa75c929', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002',               'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
+('44444444-4444-4444-4444-444444444444', 'cognito-sub-chofer-003',               'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
+('55555555-5555-5555-5555-555555555555', NULL,                                   'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
 -- =========================================================
 -- CONDUCTORES

--- a/docs/reporte-validacion-bd-endpoints.md
+++ b/docs/reporte-validacion-bd-endpoints.md
@@ -1,0 +1,1955 @@
+# Reporte de validacion de base de datos y endpoints
+
+Proyecto: NANU TECH Backend  
+Fecha de validacion: 2026-05-01  
+Base local usada para pruebas: `nanutech_local`  
+Motor esperado: PostgreSQL  
+Alcance: estructura de base de datos, seed, endpoints existentes, simulaciones SQL para endpoints futuros, pruebas locales y observaciones para nube.
+
+> Nota de seguridad: este reporte no incluye la contrasena local de PostgreSQL. Para reproducir las pruebas, cada integrante debe configurar sus propias variables `DB_*`.
+
+---
+
+## 1. Resumen ejecutivo
+
+El proyecto fue revisado con la nueva base de datos aplicada. La base local `nanutech_local` conecto correctamente y contiene las estructuras nuevas requeridas para Sprint 2 y Sprint 3:
+
+- `gps_importacion_errores`
+- `gps_proveedor_formatos`
+- `contrato_tarifas.tarifa_por_tonelada`
+- indice unico para evitar duplicados GPS por proveedor, unidad y fecha/hora
+
+Tambien se verifico que los endpoints actualmente implementados sigan funcionando con la base real local.
+
+Resultado general:
+
+| Area | Resultado |
+| --- | --- |
+| Conexion a PostgreSQL local | OK |
+| Aplicacion de schema desde cero en base temporal | OK |
+| Aplicacion de seed desde cero en base temporal | OK |
+| Tests automatizados `npm test` | OK |
+| Smoke local de auth | OK |
+| Handlers actuales contra `nanutech_local` | OK |
+| `sam build` | OK |
+| `sam validate` | Falla por runtime Lambda `nodejs20.x` deprecado |
+
+Conclusion: localmente el proyecto funciona con la base nueva. La brecha principal para nube no esta en la base de datos, sino en `template.yaml`, porque todas las Lambdas heredan `Runtime: nodejs20.x`, runtime que SAM ya marca como deprecado al 2026-04-30.
+
+---
+
+## 2. Configuracion usada para validar localmente
+
+Las pruebas de conexion real se hicieron con variables equivalentes a estas:
+
+```powershell
+$env:DB_HOST="localhost"
+$env:DB_USER="postgres"
+$env:DB_PASSWORD="<password local omitido>"
+$env:DB_NAME="nanutech_local"
+$env:DB_PORT="5432"
+$env:DB_SSL_ENABLED="false"
+```
+
+Consulta de conexion ejecutada:
+
+```sql
+SELECT
+  current_database() AS database,
+  current_user AS user,
+  inet_server_addr() AS host,
+  inet_server_port() AS port;
+```
+
+Resultado:
+
+| Campo | Valor |
+| --- | --- |
+| database | `nanutech_local` |
+| user | `postgres` |
+| host | `::1` |
+| port | `5432` |
+
+---
+
+## 3. Archivos de base de datos involucrados
+
+| Archivo | Rol |
+| --- | --- |
+| `db/schema.sql` | Esquema SQL principal para PostgreSQL |
+| `db/seed.sql` | Datos iniciales y datos de prueba |
+| `db/schema.mjs` | Exporta `schemaSQL` para scripts Node |
+| `db/seed.mjs` | Exporta `seedSQL` para scripts Node |
+| `db/seed/seed.sql` | Seed en formato compatible con migraciones |
+| `db/migrations/1775537760192_sprint1-database.sql` | Migracion/baseline SQL sincronizada |
+| `scripts/db-init-local.mjs` | Script para reiniciar esquema, aplicar schema y cargar seed |
+
+El script local actual realiza:
+
+1. Conexion usando variables `DB_*`.
+2. `DROP SCHEMA IF EXISTS public CASCADE`.
+3. `CREATE SCHEMA public`.
+4. Aplicacion de `schemaSQL`.
+5. Aplicacion de `seedSQL`.
+
+Esto implica que `node scripts\db-init-local.mjs` es destructivo para la base apuntada por `DB_NAME`: elimina el esquema `public` y lo reconstruye.
+
+---
+
+## 4. Objetos principales de la base de datos
+
+La base validada contiene 29 tablas principales.
+
+### 4.1 Tablas
+
+| Tabla | Proposito funcional |
+| --- | --- |
+| `usuarios` | Usuarios internos, roles, estado y datos de perfil |
+| `login_intentos` | Control de intentos fallidos de login local |
+| `password_reset_tokens` | Tokens/codigos para recuperacion de cuenta |
+| `sesiones_usuario` | Sesiones de usuario y estado de sesion |
+| `auditoria_accesos` | Auditoria de accesos, intentos y acciones |
+| `conductores` | Datos operativos de conductores |
+| `contactos_emergencia` | Contactos de emergencia de conductores |
+| `licencias_conducir` | Licencias de conductores |
+| `conductores_historial` | Historial de cambios de conductores |
+| `gps_dispositivos` | Dispositivos GPS asociados a unidades |
+| `unidades` | Tabla principal de camiones/unidades modernas |
+| `camiones` | Tabla legacy usada por endpoints actuales de camiones |
+| `camion_mantenimientos` | Mantenimientos preventivos/correctivos |
+| `asignaciones_conductor_unidad` | Asignacion activa o historica conductor-unidad |
+| `contratos` | Contratos comerciales |
+| `contrato_rutas` | Ruta origen/destino/distancia de contrato |
+| `contrato_tarifas` | Tarifas por contrato |
+| `contrato_unidades` | Unidades asignadas a contratos |
+| `contratos_historial` | Historial de cambios del contrato |
+| `jornadas` | Jornadas laborales y operativas |
+| `alertas_jornada` | Alertas operativas asociadas a jornadas |
+| `alertas_historial` | Historial de acciones sobre alertas |
+| `ubicaciones_jornada` | Ubicaciones asociadas a una jornada |
+| `gps_importaciones` | Cabecera de carga/importacion GPS |
+| `gps_importacion_errores` | Errores por fila/campo durante importacion GPS |
+| `gps_proveedor_formatos` | Mapeos de columnas por proveedor GPS |
+| `gps_registros` | Registros GPS normalizados |
+| `gps_eventos` | Eventos GPS operativos |
+| `combustible_registros` | Abastecimientos de combustible |
+
+### 4.2 Vistas
+
+| Vista | Uso esperado |
+| --- | --- |
+| `vw_alertas_panel` | Panel operativo de alertas |
+| `vw_camiones_operativos` | Vista completa para camiones/unidades |
+| `vw_conductores_full` | Vista enriquecida de conductores |
+| `vw_dashboard_resumen` | Resumen ejecutivo general |
+| `vw_historial_jornadas_chofer` | Historial mensual/operativo del chofer |
+| `vw_seguimiento_jornadas` | Seguimiento tabular de jornadas |
+| `vw_tracking_gps` | Tracking GPS con placa y unidad |
+
+### 4.3 Enums
+
+| Enum | Valores |
+| --- | --- |
+| `categoria_licencia` | `A-I`, `A-II-a`, `A-II-b`, `A-III-a`, `A-III-b`, `A-III-c`, `C`, `D`, `E` |
+| `estado_alerta_operativa` | `ACTIVA`, `EN_PROCESO`, `RESUELTA`, `FALSA_ALARMA` |
+| `estado_asignacion` | `ACTIVA`, `FINALIZADA`, `CANCELADA` |
+| `estado_combustible` | `BORRADOR`, `PENDIENTE_SINCRONIZACION`, `SINCRONIZADO`, `ANULADO` |
+| `estado_contrato` | `VIGENTE`, `VENCIDO`, `SUSPENDIDO`, `INACTIVO` |
+| `estado_importacion` | `PENDIENTE`, `PROCESADA`, `PROCESADA_CON_ERRORES`, `RECHAZADA` |
+| `estado_jornada` | `REGISTRADA`, `PENDIENTE`, `EN_PROCESO`, `COMPLETADA`, `CANCELADA` |
+| `estado_operacional_conductor` | `DISPONIBLE`, `EN_RUTA`, `DESCANSO`, `LICENCIA`, `INACTIVO` |
+| `estado_sesion` | `ACTIVA`, `EXPIRADA`, `CERRADA`, `REVOCADA` |
+| `estado_tracking` | `MOVIENDO`, `DETENIDO`, `EXCESO_VELOCIDAD` |
+| `estado_unidad` | `DISPONIBLE`, `EN_JORNADA`, `EN_AUXILIO`, `MANTENIMIENTO`, `INACTIVA` |
+| `estado_usuario` | `ACTIVO`, `INACTIVO`, `BLOQUEADO` |
+| `proveedor_gps` | `GPSCONTROL`, `GLOBALGPS`, `OTRO` |
+| `resultado_auditoria` | `EXITOSO`, `FALLIDO` |
+| `rol_usuario` | `ADMIN`, `CHOFER`, `GERENTE` |
+| `severidad_alerta` | `BAJA`, `MEDIA`, `ALTA`, `CRITICA` |
+| `tipo_alerta` | `PANICO`, `AUXILIO_MECANICO`, `OBSERVACION` |
+| `tipo_combustible` | `DIESEL`, `GASOLINA`, `GNV`, `GLP`, `ELECTRICO`, `HIBRIDO` |
+| `tipo_comprobante_combustible` | `BOLETA`, `FACTURA`, `TICKET`, `OTRO` |
+| `tipo_evento_gps` | `MOVIMIENTO`, `DETENCION`, `EXCESO_VELOCIDAD`, `FUERA_RUTA`, `GPS_OFFLINE` |
+| `tipo_mantenimiento` | `PREVENTIVO`, `CORRECTIVO`, `INSPECCION` |
+| `tipo_registro_ubicacion` | `INICIO`, `FIN`, `ALERTA`, `TRACKING`, `COMBUSTIBLE` |
+| `tipo_servicio_contrato` | `POR_VIAJE`, `POR_HORA`, `POR_TONELADA`, `POR_KM`, `MENSUAL` |
+
+Observacion importante: para `gps_registros.estado`, el valor correcto de movimiento es `MOVIENDO`, no `MOVIMIENTO`. `MOVIMIENTO` existe como `tipo_evento_gps`, no como `estado_tracking`.
+
+---
+
+## 5. Diccionario de tablas
+
+Esta seccion resume las columnas reales leidas desde PostgreSQL.
+
+### `usuarios`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `cognito_sub` | `varchar` | No |
+| `correo` | `varchar` | Si |
+| `nombres` | `varchar` | Si |
+| `apellidos` | `varchar` | Si |
+| `rol` | `rol_usuario` | Si |
+| `telefono` | `varchar` | No |
+| `dni` | `varchar` | No |
+| `activo` | `boolean` | Si |
+| `estado` | `estado_usuario` | Si |
+| `ultimo_acceso` | `timestamp` | No |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+### `login_intentos`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `email` | `varchar` | Si |
+| `intentos_fallidos` | `integer` | Si |
+| `ultimo_intento` | `timestamp` | No |
+| `bloqueado_hasta` | `timestamp` | No |
+
+### `password_reset_tokens`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `usuario_id` | `uuid` | No |
+| `email` | `varchar` | Si |
+| `token` | `varchar` | Si |
+| `expira_at` | `timestamp` | Si |
+| `usado` | `boolean` | Si |
+| `usado_at` | `timestamp` | No |
+| `created_at` | `timestamp` | Si |
+
+### `sesiones_usuario`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `usuario_id` | `uuid` | Si |
+| `access_token_jti` | `varchar` | No |
+| `refresh_token_jti` | `varchar` | No |
+| `expira_at` | `timestamp` | Si |
+| `ultimo_evento_at` | `timestamp` | Si |
+| `estado` | `estado_sesion` | Si |
+| `created_at` | `timestamp` | Si |
+
+### `auditoria_accesos`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `usuario_id` | `uuid` | No |
+| `correo` | `varchar` | No |
+| `rol` | `rol_usuario` | No |
+| `accion` | `varchar` | Si |
+| `resultado` | `resultado_auditoria` | Si |
+| `ip_address` | `inet` | No |
+| `user_agent` | `text` | No |
+| `dispositivo` | `varchar` | No |
+| `detalle` | `text` | No |
+| `created_at` | `timestamp` | Si |
+
+### `conductores`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `usuario_id` | `uuid` | Si |
+| `fecha_nacimiento` | `date` | No |
+| `direccion` | `varchar` | No |
+| `fecha_ingreso` | `date` | No |
+| `estado_operacional` | `estado_operacional_conductor` | Si |
+| `current_shift_id` | `uuid` | No |
+| `observaciones` | `text` | No |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+### `contactos_emergencia`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `conductor_id` | `uuid` | Si |
+| `nombre` | `varchar` | Si |
+| `telefono` | `varchar` | Si |
+| `parentesco` | `varchar` | No |
+| `es_principal` | `boolean` | Si |
+| `created_at` | `timestamp` | Si |
+
+### `licencias_conducir`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `conductor_id` | `uuid` | Si |
+| `numero_licencia` | `varchar` | Si |
+| `categoria` | `categoria_licencia` | Si |
+| `fecha_emision` | `date` | No |
+| `fecha_vencimiento` | `date` | Si |
+| `autoridad_emisora` | `varchar` | No |
+| `activa` | `boolean` | Si |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+### `conductores_historial`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `conductor_id` | `uuid` | Si |
+| `accion` | `varchar` | Si |
+| `campo` | `varchar` | No |
+| `valor_anterior` | `text` | No |
+| `valor_nuevo` | `text` | No |
+| `detalle` | `text` | No |
+| `usuario_id` | `uuid` | No |
+| `ip_address` | `inet` | No |
+| `created_at` | `timestamp` | Si |
+
+### `gps_dispositivos`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `codigo_equipo` | `varchar` | Si |
+| `proveedor` | `proveedor_gps` | Si |
+| `imei` | `varchar` | No |
+| `numero_sim` | `varchar` | No |
+| `activo` | `boolean` | Si |
+| `ultima_sincronizacion` | `timestamp` | No |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+### `unidades`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `placa` | `varchar` | Si |
+| `marca` | `varchar` | No |
+| `modelo` | `varchar` | No |
+| `anio` | `integer` | No |
+| `capacidad_ton` | `numeric` | No |
+| `estado` | `estado_unidad` | Si |
+| `gps_habilitado` | `boolean` | Si |
+| `activo` | `boolean` | Si |
+| `vin` | `varchar` | No |
+| `color` | `varchar` | No |
+| `tipo_combustible` | `tipo_combustible` | No |
+| `fecha_registro` | `date` | No |
+| `ultima_fecha_mantenimiento` | `date` | No |
+| `proxima_fecha_mantenimiento` | `date` | No |
+| `kilometraje_actual` | `numeric` | Si |
+| `gps_device_id` | `uuid` | No |
+| `notas` | `text` | No |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+### `camiones`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `bigint` | Si |
+| `unidad_id` | `uuid` | No |
+| `placa` | `varchar` | Si |
+| `marca` | `varchar` | No |
+| `modelo` | `varchar` | No |
+| `estado` | `varchar` | Si |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+Observacion: esta tabla es legacy y los endpoints actuales de camiones la usan. Para los endpoints futuros de detalle tecnico completo conviene usar `unidades` o `vw_camiones_operativos`.
+
+### `camion_mantenimientos`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `unidad_id` | `uuid` | Si |
+| `tipo` | `tipo_mantenimiento` | Si |
+| `fecha_programada` | `date` | No |
+| `fecha_ejecutada` | `date` | No |
+| `kilometraje` | `numeric` | No |
+| `costo` | `numeric` | No |
+| `proveedor_taller` | `varchar` | No |
+| `observaciones` | `text` | No |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+### `asignaciones_conductor_unidad`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `conductor_id` | `uuid` | Si |
+| `unidad_id` | `uuid` | Si |
+| `fecha_inicio` | `timestamp` | Si |
+| `fecha_fin` | `timestamp` | No |
+| `estado` | `estado_asignacion` | Si |
+| `creado_por` | `uuid` | No |
+| `observaciones` | `text` | No |
+| `created_at` | `timestamp` | Si |
+
+### `contratos`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `codigo` | `varchar` | Si |
+| `cliente` | `varchar` | Si |
+| `ruc` | `varchar` | No |
+| `descripcion` | `text` | No |
+| `tipo_servicio` | `tipo_servicio_contrato` | Si |
+| `fecha_inicio` | `date` | Si |
+| `fecha_fin` | `date` | No |
+| `tarifa` | `numeric` | No |
+| `moneda` | `varchar` | Si |
+| `estado` | `estado_contrato` | Si |
+| `activo` | `boolean` | Si |
+| `updated_by` | `uuid` | No |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+### `contrato_rutas`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `contrato_id` | `uuid` | Si |
+| `origen` | `varchar` | Si |
+| `destino` | `varchar` | Si |
+| `distancia_estimada_km` | `numeric` | Si |
+| `created_at` | `timestamp` | Si |
+
+### `contrato_tarifas`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `contrato_id` | `uuid` | Si |
+| `tarifa_base` | `numeric` | Si |
+| `tarifa_por_km` | `numeric` | Si |
+| `tarifa_por_hora` | `numeric` | Si |
+| `tarifa_por_tonelada` | `numeric` | Si |
+| `tarifa_espera` | `numeric` | Si |
+| `total_referencial` | `numeric` | Si |
+| `created_at` | `timestamp` | Si |
+
+Validacion especifica:
+
+| Columna | Tipo | Precision | Escala | Default | Nullable |
+| --- | --- | --- | --- | --- | --- |
+| `tarifa_por_tonelada` | `numeric` | 12 | 2 | `0` | No |
+
+### `contrato_unidades`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `contrato_id` | `uuid` | Si |
+| `unidad_id` | `uuid` | Si |
+| `assigned_at` | `timestamp` | Si |
+| `assigned_by` | `uuid` | No |
+| `activo` | `boolean` | Si |
+
+### `contratos_historial`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `contrato_id` | `uuid` | Si |
+| `accion` | `varchar` | Si |
+| `campo` | `varchar` | No |
+| `valor_anterior` | `text` | No |
+| `valor_nuevo` | `text` | No |
+| `detalle` | `text` | No |
+| `usuario_id` | `uuid` | No |
+| `ip_address` | `inet` | No |
+| `created_at` | `timestamp` | Si |
+
+### `jornadas`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `codigo` | `varchar` | No |
+| `conductor_id` | `uuid` | Si |
+| `unidad_id` | `uuid` | Si |
+| `contrato_id` | `uuid` | Si |
+| `creado_por` | `uuid` | Si |
+| `fecha_jornada` | `date` | Si |
+| `hora_inicio_programada` | `timestamp` | No |
+| `hora_fin_programada` | `timestamp` | No |
+| `hora_inicio` | `timestamp` | No |
+| `hora_fin` | `timestamp` | No |
+| `origen` | `varchar` | No |
+| `destino` | `varchar` | No |
+| `km_estimados` | `numeric` | Si |
+| `km_recorridos` | `numeric` | Si |
+| `tipo_carga` | `varchar` | No |
+| `peso_carga_ton` | `numeric` | No |
+| `observaciones` | `varchar` | No |
+| `observacion_admin` | `text` | No |
+| `estado` | `estado_jornada` | Si |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+Observacion: para observaciones simples, la tabla soporta texto en `observaciones` y `observacion_admin`. Si se requiere historial de muchas observaciones por jornada, convendria una tabla adicional en una siguiente iteracion.
+
+### `alertas_jornada`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `codigo` | `varchar` | No |
+| `jornada_id` | `uuid` | Si |
+| `tipo` | `tipo_alerta` | Si |
+| `estado` | `estado_alerta_operativa` | Si |
+| `severidad` | `severidad_alerta` | Si |
+| `detalle` | `text` | No |
+| `tipo_falla_mecanica` | `varchar` | No |
+| `latitud` | `numeric` | Si |
+| `longitud` | `numeric` | Si |
+| `direccion` | `varchar` | No |
+| `fecha_hora` | `timestamp` | Si |
+| `atendida` | `boolean` | Si |
+| `atendida_por` | `uuid` | No |
+| `atendida_at` | `timestamp` | No |
+| `detalle_resolucion` | `text` | No |
+| `servicio_tecnico_realizado` | `text` | No |
+| `telefono_contactado` | `varchar` | No |
+| `bloqueo_sos_activo` | `boolean` | Si |
+| `created_at` | `timestamp` | Si |
+
+### `alertas_historial`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `alerta_id` | `uuid` | Si |
+| `accion` | `varchar` | Si |
+| `detalle` | `text` | No |
+| `usuario_id` | `uuid` | No |
+| `created_at` | `timestamp` | Si |
+
+### `ubicaciones_jornada`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `jornada_id` | `uuid` | Si |
+| `unidad_id` | `uuid` | No |
+| `latitud` | `numeric` | Si |
+| `longitud` | `numeric` | Si |
+| `direccion` | `varchar` | No |
+| `fecha_hora` | `timestamp` | Si |
+| `tipo_registro` | `tipo_registro_ubicacion` | Si |
+| `velocidad_kmh` | `numeric` | No |
+| `rumbo` | `numeric` | No |
+| `odometro_km` | `numeric` | No |
+| `proveedor` | `proveedor_gps` | No |
+| `created_at` | `timestamp` | Si |
+
+### `gps_importaciones`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `proveedor` | `proveedor_gps` | Si |
+| `nombre_archivo` | `varchar` | Si |
+| `cargado_por` | `uuid` | No |
+| `total_registros` | `integer` | Si |
+| `registros_validos` | `integer` | Si |
+| `registros_invalidos` | `integer` | Si |
+| `estado` | `estado_importacion` | Si |
+| `observaciones` | `text` | No |
+| `created_at` | `timestamp` | Si |
+| `processed_at` | `timestamp` | No |
+
+### `gps_importacion_errores`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `importacion_id` | `uuid` | Si |
+| `numero_fila` | `integer` | Si |
+| `campo` | `varchar` | No |
+| `valor_recibido` | `text` | No |
+| `motivo_error` | `text` | Si |
+| `raw_payload` | `jsonb` | No |
+| `created_at` | `timestamp` | Si |
+
+Validacion especifica:
+
+- Filas seed cargadas: `2`
+- FK hacia `gps_importaciones(id)` con `ON DELETE CASCADE`
+- Indice: `idx_gps_importacion_errores_importacion`
+
+### `gps_proveedor_formatos`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `proveedor` | `varchar` | Si |
+| `nombre_formato` | `varchar` | Si |
+| `mapeo_columnas` | `jsonb` | Si |
+| `activo` | `boolean` | Si |
+| `created_at` | `timestamp` | Si |
+| `updated_at` | `timestamp` | Si |
+
+Validacion especifica:
+
+- Filas seed cargadas: `3`
+- Constraint unica: `UNIQUE (proveedor, nombre_formato)`
+- Trigger de actualizacion: `tg_gps_proveedor_formatos_updated_at`
+
+### `gps_registros`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `importacion_id` | `uuid` | No |
+| `unidad_id` | `uuid` | Si |
+| `jornada_id` | `uuid` | No |
+| `fecha_hora` | `timestamp` | Si |
+| `latitud` | `numeric` | Si |
+| `longitud` | `numeric` | Si |
+| `velocidad_kmh` | `numeric` | No |
+| `rumbo` | `numeric` | No |
+| `odometro_km` | `numeric` | No |
+| `estado` | `estado_tracking` | No |
+| `proveedor` | `proveedor_gps` | Si |
+| `raw_payload` | `jsonb` | No |
+| `created_at` | `timestamp` | Si |
+
+Validacion especifica:
+
+- Filas seed cargadas: `7`
+- Indice unico: `uq_gps_registros_proveedor_unidad_fecha`
+- Definicion: `UNIQUE (proveedor, unidad_id, fecha_hora)`
+
+Distribucion de estados:
+
+| Estado | Total |
+| --- | ---: |
+| `DETENIDO` | 2 |
+| `EXCESO_VELOCIDAD` | 1 |
+| `MOVIENDO` | 4 |
+
+### `gps_eventos`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `unidad_id` | `uuid` | Si |
+| `jornada_id` | `uuid` | No |
+| `tipo_evento` | `tipo_evento_gps` | Si |
+| `estado` | `estado_alerta_operativa` | No |
+| `fecha_hora_inicio` | `timestamp` | Si |
+| `fecha_hora_fin` | `timestamp` | No |
+| `velocidad_maxima` | `numeric` | No |
+| `latitud` | `numeric` | No |
+| `longitud` | `numeric` | No |
+| `distancia_km` | `numeric` | No |
+| `detalle` | `text` | No |
+| `created_at` | `timestamp` | Si |
+
+### `combustible_registros`
+
+| Columna | Tipo | Requerida |
+| --- | --- | --- |
+| `id` | `uuid` | Si |
+| `jornada_id` | `uuid` | No |
+| `unidad_id` | `uuid` | Si |
+| `conductor_id` | `uuid` | Si |
+| `contrato_id` | `uuid` | No |
+| `tipo_comprobante` | `tipo_comprobante_combustible` | No |
+| `numero_comprobante` | `varchar` | No |
+| `galones` | `numeric` | Si |
+| `costo_total` | `numeric` | Si |
+| `kilometraje_actual` | `numeric` | Si |
+| `kilometraje_anterior` | `numeric` | No |
+| `rendimiento_km_galon` | `numeric` | No |
+| `foto_comprobante_url` | `text` | No |
+| `observaciones` | `text` | No |
+| `latitud` | `numeric` | No |
+| `longitud` | `numeric` | No |
+| `estado` | `estado_combustible` | Si |
+| `sincronizado` | `boolean` | Si |
+| `registrado_at` | `timestamp` | Si |
+| `created_at` | `timestamp` | Si |
+
+---
+
+## 6. Indices y constraints relevantes
+
+Indices principales verificados:
+
+| Indice | Tabla | Proposito |
+| --- | --- | --- |
+| `idx_usuarios_rol` | `usuarios` | Filtro por rol |
+| `idx_usuarios_estado` | `usuarios` | Filtro por estado |
+| `idx_sesiones_usuario` | `sesiones_usuario` | Busqueda de sesiones por usuario |
+| `idx_sesiones_estado` | `sesiones_usuario` | Filtro por estado de sesion |
+| `idx_reset_email` | `password_reset_tokens` | Recuperacion por email |
+| `idx_auditoria_usuario` | `auditoria_accesos` | Auditoria por usuario |
+| `idx_auditoria_fecha` | `auditoria_accesos` | Auditoria por fecha |
+| `idx_conductores_estado_operacional` | `conductores` | Selectores de conductores disponibles |
+| `idx_unidades_estado` | `unidades` | Selectores y panel de flota |
+| `idx_unidades_gps_device` | `unidades` | Relacion con GPS |
+| `idx_camiones_unidad_id` | `camiones` | Relacion legacy con unidades |
+| `idx_camiones_estado` | `camiones` | Filtro legacy de camiones |
+| `idx_mantenimientos_unidad` | `camion_mantenimientos` | Historial por unidad |
+| `idx_contratos_estado` | `contratos` | Filtro por estado de contrato |
+| `idx_contratos_tipo_servicio` | `contratos` | Reportes por tipo de servicio |
+| `idx_jornadas_fecha` | `jornadas` | Reportes por fecha |
+| `idx_jornadas_estado` | `jornadas` | Filtro por estado |
+| `idx_jornadas_conductor` | `jornadas` | Jornadas por conductor |
+| `idx_jornadas_unidad` | `jornadas` | Jornadas por unidad |
+| `idx_jornadas_contrato` | `jornadas` | Jornadas por contrato |
+| `idx_alertas_jornada` | `alertas_jornada` | Alertas por jornada |
+| `idx_alertas_tipo` | `alertas_jornada` | Alertas por tipo |
+| `idx_alertas_estado` | `alertas_jornada` | Alertas por estado |
+| `idx_alertas_fecha_hora` | `alertas_jornada` | Alertas por fecha/hora |
+| `idx_ubicaciones_jornada` | `ubicaciones_jornada` | Ubicaciones por jornada |
+| `idx_ubicaciones_unidad` | `ubicaciones_jornada` | Ubicaciones por unidad |
+| `idx_ubicaciones_fecha_hora` | `ubicaciones_jornada` | Tracking por fecha/hora |
+| `idx_gps_importacion_errores_importacion` | `gps_importacion_errores` | Errores por importacion |
+| `idx_gps_registros_unidad` | `gps_registros` | GPS por unidad |
+| `idx_gps_registros_jornada` | `gps_registros` | GPS por jornada |
+| `idx_gps_registros_fecha_hora` | `gps_registros` | GPS por fecha/hora |
+| `idx_gps_eventos_unidad` | `gps_eventos` | Eventos por unidad |
+| `idx_gps_eventos_jornada` | `gps_eventos` | Eventos por jornada |
+| `idx_gps_eventos_tipo` | `gps_eventos` | Eventos por tipo |
+| `idx_combustible_unidad` | `combustible_registros` | Combustible por unidad |
+| `idx_combustible_conductor` | `combustible_registros` | Combustible por conductor |
+| `idx_combustible_jornada` | `combustible_registros` | Combustible por jornada |
+
+Constraints unicas relevantes:
+
+| Constraint/indice | Tabla | Regla |
+| --- | --- | --- |
+| `uq_asignacion_activa_conductor` | `asignaciones_conductor_unidad` | Un conductor no debe tener mas de una asignacion activa |
+| `uq_asignacion_activa_unidad` | `asignaciones_conductor_unidad` | Una unidad no debe tener mas de una asignacion activa |
+| `uq_contrato_unidad_activa` | `contrato_unidades` | Evita duplicar una unidad activa en el mismo contrato |
+| `uq_jornada_activa_unidad` | `jornadas` | Evita mas de una jornada activa por unidad |
+| `uq_jornada_activa_chofer` | `jornadas` | Evita mas de una jornada activa por chofer |
+| `uq_gps_registros_proveedor_unidad_fecha` | `gps_registros` | Evita duplicados GPS por proveedor, unidad y fecha/hora |
+| `uq_gps_proveedor_formato` | `gps_proveedor_formatos` | Evita duplicar formato por proveedor y nombre |
+
+---
+
+## 7. Seed validado
+
+Conteos aproximados de filas en `nanutech_local` despues de aplicar el seed:
+
+| Tabla | Filas |
+| --- | ---: |
+| `usuarios` | 5 |
+| `conductores` | 3 |
+| `unidades` | 3 |
+| `camiones` | 3 |
+| `contratos` | 3 |
+| `contrato_rutas` | 3 |
+| `contrato_tarifas` | 3 |
+| `contrato_unidades` | 3 |
+| `jornadas` | 3 |
+| `gps_dispositivos` | 3 |
+| `gps_importaciones` | 2 |
+| `gps_importacion_errores` | 2 |
+| `gps_proveedor_formatos` | 3 |
+| `gps_registros` | 7 |
+| `gps_eventos` | 3 |
+| `combustible_registros` | 1 |
+| `auditoria_accesos` | 3 |
+| `alertas_jornada` | 2 |
+| `alertas_historial` | 2 |
+| `camion_mantenimientos` | 2 |
+| `ubicaciones_jornada` | 4 |
+| `sesiones_usuario` | 2 |
+| `login_intentos` | 1 |
+| `password_reset_tokens` | 1 |
+
+El seed incluye datos suficientes para probar:
+
+- Usuarios por rol.
+- Conductores disponibles/en ruta.
+- Unidades disponibles/en jornada/mantenimiento.
+- Contratos vigentes.
+- Contrato por tonelada.
+- Jornadas registradas/en proceso/completadas.
+- GPS con movimiento, detenido y exceso de velocidad.
+- Importacion GPS con errores de fila.
+- Formatos de proveedores GPS.
+- Combustible.
+- Auditoria de accesos.
+- Alertas operativas.
+
+---
+
+## 8. Prueba de inicializacion desde cero
+
+Para no tocar la base real `nanutech_local`, se creo una base temporal con nombre similar a:
+
+```txt
+nanutech_tmp_codex_<timestamp>
+```
+
+Luego se ejecuto:
+
+```powershell
+node scripts\db-init-local.mjs
+```
+
+Resultado:
+
+```txt
+==> Inicializando base local para HU01
+==> Limpiando esquema previo
+==> Aplicando schema
+==> Aplicando seed
+==> Base local inicializada correctamente
+```
+
+Validacion posterior:
+
+| Verificacion | Resultado |
+| --- | --- |
+| Tablas creadas | 29 |
+| Usuarios cargados | 5 |
+| Camiones cargados | 3 |
+| Contratos cargados | 3 |
+| GPS registros cargados | 7 |
+| Errores importacion GPS cargados | 2 |
+| Formatos proveedor GPS cargados | 3 |
+
+La base temporal fue eliminada al terminar la prueba.
+
+---
+
+## 9. Endpoints implementados actualmente en codigo
+
+El codigo actual no tiene todavia las 60-70 rutas propuestas. Estas son las rutas realmente implementadas en los handlers:
+
+### Auth
+
+| Metodo | Ruta | Handler |
+| --- | --- | --- |
+| `POST` | `/auth/login` | `src/functions/auth-services/authHandler.mjs` |
+| `GET` | `/auth/me` | `src/functions/auth-services/authHandler.mjs` |
+| `POST` | `/auth/forgot-password` | `src/functions/auth-services/authHandler.mjs` |
+| `POST` | `/auth/forgot-password/confirm` | `src/functions/auth-services/authHandler.mjs` |
+
+Observaciones:
+
+- El contrato propuesto por frontend usa `correo`, `codigo`, `nuevaPassword`.
+- El backend actual espera `email`, `code`, `newPassword`.
+- El auth local actual usa usuarios en memoria, no PostgreSQL.
+- En modo Cognito si usa PostgreSQL para resolver perfil interno.
+- No existen todavia `/auth/logout` ni `/auth/refresh`.
+
+### Jornadas
+
+| Metodo | Ruta | Handler |
+| --- | --- | --- |
+| `POST` | `/jornadas` | `src/functions/jornada-services/jornadaHandler.mjs` |
+| `GET` | `/jornadas` | `src/functions/jornada-services/jornadaHandler.mjs` |
+| `GET` | `/jornadas/actual/{conductorId}` | `src/functions/jornada-services/jornadaHandler.mjs` |
+| `POST` | `/jornadas/iniciar` | `src/functions/jornada-services/jornadaHandler.mjs` |
+| `POST` | `/jornadas/finalizar` | `src/functions/jornada-services/jornadaHandler.mjs` |
+
+Observaciones:
+
+- Las rutas futuras proponen `/jornadas/{jornadaId}/iniciar-turno` y `/jornadas/{jornadaId}/finalizar-turno`.
+- El backend actual usa body con `jornada_id` para iniciar/finalizar.
+- No existen todavia resumen, selectores, seguimiento, detalle por ID, observaciones, export CSV ni endpoints de chofer.
+
+### Camiones
+
+| Metodo | Ruta | Handler |
+| --- | --- | --- |
+| `GET` | `/camiones` | `src/functions/camion-services/camionHandler.mjs` |
+| `GET` | `/camiones/{id}` | `src/functions/camion-services/camionHandler.mjs` |
+
+Observaciones:
+
+- El backend actual usa tabla legacy `camiones`.
+- Para los endpoints futuros tecnicos conviene migrar consultas a `unidades` o `vw_camiones_operativos`.
+- No existen todavia PATCH, POST, export, GPS por camion ni mantenimientos.
+
+### Conductores
+
+| Metodo | Ruta | Handler |
+| --- | --- | --- |
+| `GET` | `/conductores` | `src/functions/conductor-services/conductorHandler.mjs` |
+
+### Unidades
+
+| Metodo | Ruta | Handler |
+| --- | --- | --- |
+| `GET` | `/unidades/disponibles` | `src/functions/unidad-services/unidadHandler.mjs` |
+
+### Contratos
+
+| Metodo | Ruta | Handler |
+| --- | --- | --- |
+| `GET` | `/contratos/vigentes` | `src/functions/contrato-services/contratoHandler.mjs` |
+
+Observaciones:
+
+- La base soporta el modulo completo de contratos, pero el backend aun solo expone vigentes.
+
+---
+
+## 10. Pruebas de endpoints/handlers realizadas
+
+Las pruebas se ejecutaron contra `nanutech_local`, usando los handlers reales del proyecto. No se uso servidor HTTP externo; se invocaron handlers Lambda localmente con eventos equivalentes.
+
+### 10.1 `GET /camiones`
+
+Evento:
+
+```json
+{
+  "httpMethod": "GET",
+  "resource": "/camiones"
+}
+```
+
+Resultado:
+
+| Campo | Valor |
+| --- | --- |
+| statusCode | 200 |
+| success | true |
+| message | `Camiones obtenidos exitosamente` |
+| registros devueltos | 3 |
+
+Consulta observada:
+
+```sql
+SELECT id, placa, marca, modelo, estado
+FROM camiones
+ORDER BY id;
+```
+
+### 10.2 `GET /conductores`
+
+Evento:
+
+```json
+{
+  "httpMethod": "GET",
+  "resource": "/conductores"
+}
+```
+
+Resultado:
+
+| Campo | Valor |
+| --- | --- |
+| statusCode | 200 |
+| success | true |
+| message | `Conductores obtenidos exitosamente` |
+| registros devueltos | 3 |
+
+### 10.3 `GET /unidades/disponibles`
+
+Evento:
+
+```json
+{
+  "httpMethod": "GET",
+  "resource": "/unidades/disponibles"
+}
+```
+
+Resultado:
+
+| Campo | Valor |
+| --- | --- |
+| statusCode | 200 |
+| success | true |
+| message | `Unidades disponibles obtenidas exitosamente` |
+| registros devueltos | 1 |
+
+Consulta observada:
+
+```sql
+SELECT id, placa, marca, modelo, anio,
+       capacidad_ton, estado, activo
+FROM unidades
+WHERE activo = TRUE
+  AND estado = 'DISPONIBLE'
+ORDER BY placa;
+```
+
+### 10.4 `GET /contratos/vigentes`
+
+Evento:
+
+```json
+{
+  "httpMethod": "GET",
+  "resource": "/contratos/vigentes"
+}
+```
+
+Resultado:
+
+| Campo | Valor |
+| --- | --- |
+| statusCode | 200 |
+| success | true |
+| message | `Contratos obtenidos exitosamente` |
+| registros devueltos | 3 |
+
+Consulta observada:
+
+```sql
+SELECT id, codigo, cliente, descripcion,
+       fecha_inicio, fecha_fin, tarifa, moneda, estado, activo
+FROM contratos
+WHERE activo = TRUE
+  AND estado = 'VIGENTE'
+  AND fecha_inicio <= CURRENT_DATE
+  AND (fecha_fin IS NULL OR fecha_fin >= CURRENT_DATE)
+ORDER BY cliente;
+```
+
+### 10.5 `GET /jornadas`
+
+Evento:
+
+```json
+{
+  "httpMethod": "GET",
+  "resource": "/jornadas"
+}
+```
+
+Resultado:
+
+| Campo | Valor |
+| --- | --- |
+| statusCode | 200 |
+| success | true |
+| message | `Jornadas obtenidas exitosamente.` |
+| registros devueltos | 3 |
+
+---
+
+## 11. Pruebas de auth local
+
+Comando:
+
+```powershell
+node scripts\smoke-auth-local.mjs --mode=local
+```
+
+Resultado:
+
+| Flujo | Status | Resultado |
+| --- | ---: | --- |
+| `POST /auth/login` local | 200 | OK |
+| `GET /auth/me` local | 200 | OK |
+| `POST /auth/forgot-password` local | 200 | OK |
+| Confirmacion de recuperacion local | 200 | OK |
+| Relogin local | 200 | OK |
+
+Observacion importante:
+
+El smoke de auth local usa el proveedor `local`, con usuarios en memoria. Es util para comprobar que la Lambda de auth responde, pero no valida la tabla `usuarios` de PostgreSQL para login local. Para validar usuarios reales en nube se debe usar Cognito o adaptar auth local a la base.
+
+---
+
+## 12. Tests automatizados
+
+Comando:
+
+```powershell
+npm test
+```
+
+Resultado:
+
+| Item | Resultado |
+| --- | --- |
+| Test suites | 15 passed |
+| Tests | 60 passed |
+| Snapshots | 0 |
+| Estado general | OK |
+
+Notas:
+
+- Los tests de integracion de camiones usan helper de pruebas.
+- Los tests unitarios cubren auth, jornadas, contratos, conductores, unidades y camiones.
+- Se observo un `console.error` esperado en una prueba de jornada ya iniciada; la prueba pasa y valida el error esperado.
+
+---
+
+## 13. Pruebas de build y nube
+
+### 13.1 `sam build`
+
+Comando:
+
+```powershell
+sam build
+```
+
+Resultado:
+
+| Item | Resultado |
+| --- | --- |
+| Build SAM | OK |
+| Artefactos | `.aws-sam/build` |
+| Template generado | `.aws-sam/build/template.yaml` |
+
+Advertencias no bloqueantes:
+
+- SAM intento crear enlaces simbolicos.
+- Al no tener privilegios/configuracion suficiente para symlinks en Windows, uso copia de archivos.
+- Esto no rompio el build.
+
+### 13.2 `sam validate`
+
+Comando:
+
+```powershell
+sam validate
+```
+
+Resultado:
+
+| Item | Resultado |
+| --- | --- |
+| Validacion SAM | Falla |
+| Causa | Runtime Lambda `nodejs20.x` deprecado |
+| Archivo | `template.yaml` |
+| Linea principal | `Globals.Function.Runtime` |
+
+Mensaje observado:
+
+```txt
+Runtime 'nodejs20.x' was deprecated on '2026-04-30'.
+Please consider updating to 'nodejs24.x'
+```
+
+En `template.yaml`:
+
+```yaml
+Globals:
+  Function:
+    Runtime: nodejs20.x
+```
+
+Al estar en `Globals.Function`, todas las Lambdas heredan ese runtime:
+
+- `JornadaFunction`
+- `CamionFunction`
+- `ConductorFunction`
+- `ContratoFunction`
+- `UnidadFunction`
+- `AuthFunction`
+- `MigratorFunction`
+
+Recomendacion para nube:
+
+1. Cambiar `Runtime: nodejs20.x` a `Runtime: nodejs24.x`.
+2. Ejecutar `npm test`.
+3. Ejecutar `sam build`.
+4. Ejecutar `sam validate`.
+5. Probar en ambiente testing/staging antes de produccion.
+
+---
+
+## 14. Consultas de soporte para endpoints futuros
+
+Aunque varios endpoints todavia no existen como codigo, se simularon consultas SQL para validar si la base los soporta.
+
+### 14.1 Resumen de jornadas
+
+Endpoint futuro relacionado:
+
+```txt
+GET /jornadas/resumen
+```
+
+Consulta usada:
+
+```sql
+SELECT
+  COUNT(*)::int AS total,
+  COUNT(*) FILTER (
+    WHERE estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO')
+  )::int AS activas,
+  COUNT(*) FILTER (WHERE estado = 'COMPLETADA')::int AS completadas,
+  COALESCE(SUM(km_recorridos), 0)::numeric AS km_acumulados
+FROM jornadas;
+```
+
+Resultado:
+
+| total | activas | completadas | km_acumulados |
+| ---: | ---: | ---: | ---: |
+| 3 | 2 | 1 | 646.20 |
+
+Conclusion: la base soporta este endpoint.
+
+### 14.2 Resumen de contratos
+
+Endpoint futuro relacionado:
+
+```txt
+GET /contratos/resumen
+```
+
+Consulta usada:
+
+```sql
+SELECT
+  COUNT(*)::int AS total,
+  COUNT(*) FILTER (WHERE estado = 'VIGENTE')::int AS activos,
+  COUNT(*) FILTER (WHERE fecha_fin < CURRENT_DATE)::int AS vencidos,
+  COUNT(DISTINCT unidad_id)::int AS camiones_asignados
+FROM contratos c
+LEFT JOIN contrato_unidades cu
+  ON cu.contrato_id = c.id
+ AND cu.activo;
+```
+
+Resultado:
+
+| total | activos | vencidos | camiones_asignados |
+| ---: | ---: | ---: | ---: |
+| 3 | 3 | 0 | 3 |
+
+Conclusion: la base soporta este endpoint.
+
+### 14.3 Resumen GPS
+
+Endpoint futuro relacionado:
+
+```txt
+GET /gps/resumen
+```
+
+Consulta usada:
+
+```sql
+SELECT
+  COUNT(*)::int AS total_registros,
+  COUNT(DISTINCT unidad_id) FILTER (WHERE estado = 'MOVIENDO')::int AS unidades_movimiento,
+  COUNT(DISTINCT unidad_id) FILTER (WHERE estado = 'DETENIDO')::int AS unidades_detenidas,
+  ROUND(AVG(velocidad_kmh), 2)::numeric AS velocidad_promedio
+FROM gps_registros;
+```
+
+Resultado:
+
+| total_registros | unidades_movimiento | unidades_detenidas | velocidad_promedio |
+| ---: | ---: | ---: | ---: |
+| 7 | 2 | 2 | 40.57 |
+
+Conclusion: la base soporta este endpoint. Se debe usar `MOVIENDO`, no `MOVIMIENTO`, para estado de tracking.
+
+### 14.4 Resumen de combustible
+
+Endpoint futuro relacionado:
+
+```txt
+GET /combustible/resumen
+```
+
+Consulta usada:
+
+```sql
+SELECT
+  COALESCE(SUM(galones), 0)::numeric AS galones,
+  COALESCE(SUM(costo_total), 0)::numeric AS costo,
+  ROUND(AVG(rendimiento_km_galon), 2)::numeric AS rendimiento_promedio,
+  COUNT(*)::int AS abastecimientos
+FROM combustible_registros;
+```
+
+Resultado:
+
+| galones | costo | rendimiento_promedio | abastecimientos |
+| ---: | ---: | ---: | ---: |
+| 18.50 | 420.00 | 6.49 | 1 |
+
+Conclusion: la base soporta el endpoint.
+
+### 14.5 Resumen de auditoria
+
+Endpoint futuro relacionado:
+
+```txt
+GET /auditoria/accesos/resumen
+```
+
+Consulta usada:
+
+```sql
+SELECT
+  COUNT(*)::int AS total,
+  COUNT(*) FILTER (WHERE resultado = 'EXITOSO')::int AS exitosos,
+  COUNT(*) FILTER (WHERE resultado = 'FALLIDO')::int AS fallidos,
+  COUNT(*) FILTER (WHERE accion ILIKE '%bloque%')::int AS bloqueos
+FROM auditoria_accesos;
+```
+
+Resultado:
+
+| total | exitosos | fallidos | bloqueos |
+| ---: | ---: | ---: | ---: |
+| 3 | 3 | 0 | 0 |
+
+Conclusion: la base soporta el endpoint.
+
+### 14.6 Dashboard resumen
+
+Endpoint futuro relacionado:
+
+```txt
+GET /dashboard/ejecutivo/resumen
+```
+
+Consulta usada:
+
+```sql
+SELECT *
+FROM vw_dashboard_resumen;
+```
+
+Resultado:
+
+| total_camiones | camiones_en_uso | camiones_disponibles | camiones_mantenimiento | total_conductores | conductores_en_ruta | contratos_activos | jornadas_activas | alertas_activas | km_totales_operados |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 3 | 1 | 1 | 1 | 3 | 1 | 3 | 2 | 1 | 525.40 |
+
+Conclusion: la base soporta un resumen inicial del dashboard ejecutivo.
+
+### 14.7 Proveedores GPS
+
+Endpoint futuro relacionado:
+
+```txt
+GET /gps/proveedores
+GET /catalogos/proveedores-gps
+```
+
+Consulta usada:
+
+```sql
+SELECT proveedor, COUNT(*)::int AS formatos
+FROM gps_proveedor_formatos
+WHERE activo
+GROUP BY proveedor
+ORDER BY proveedor;
+```
+
+Resultado:
+
+| proveedor | formatos |
+| --- | ---: |
+| `GLOBALGPS` | 1 |
+| `GPSCONTROL` | 2 |
+
+Conclusion: la base soporta catalogo de proveedores GPS configurados.
+
+### 14.8 Catalogo de conductores
+
+Endpoint futuro relacionado:
+
+```txt
+GET /catalogos/conductores
+```
+
+Consulta usada:
+
+```sql
+SELECT COUNT(*)::int AS total
+FROM vw_conductores_full
+WHERE rol = 'CHOFER'
+  AND estado_usuario = 'ACTIVO';
+```
+
+Resultado:
+
+| total |
+| ---: |
+| 3 |
+
+Conclusion: la base soporta selectores de conductores.
+
+### 14.9 Seguimiento de jornadas
+
+Endpoint futuro relacionado:
+
+```txt
+GET /jornadas/seguimiento
+```
+
+Consulta usada:
+
+```sql
+SELECT COUNT(*)::int AS total
+FROM vw_seguimiento_jornadas;
+```
+
+Resultado:
+
+| total |
+| ---: |
+| 3 |
+
+Conclusion: la base soporta seguimiento de jornadas.
+
+### 14.10 Tracking GPS
+
+Endpoint futuro relacionado:
+
+```txt
+GET /gps/registros
+GET /gps/tiempo-real
+```
+
+Consulta usada:
+
+```sql
+SELECT COUNT(*)::int AS total
+FROM vw_tracking_gps;
+```
+
+Resultado:
+
+| total |
+| ---: |
+| 7 |
+
+Conclusion: la base soporta consultas de tracking GPS.
+
+---
+
+## 15. Revision de endpoints futuros por modulo
+
+### 15.1 Auth y usuarios
+
+Endpoints propuestos:
+
+- `POST /auth/login`
+- `GET /auth/me`
+- `POST /auth/forgot-password`
+- `POST /auth/reset-password`
+- `POST /auth/logout`
+- `POST /auth/refresh`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| `POST /auth/login` | Parcial | Si | Local usa memoria; Cognito resuelve perfil interno en BD |
+| `GET /auth/me` | Parcial | Si | Local devuelve datos del token; Cognito cruza con BD |
+| `POST /auth/forgot-password` | Si | Si | Codigo espera `email` |
+| `POST /auth/reset-password` | Si | No con ese nombre | Existe `/auth/forgot-password/confirm` |
+| `POST /auth/logout` | Si | No | Requiere actualizar `sesiones_usuario` |
+| `POST /auth/refresh` | Si | No | Requiere flujo de refresh token |
+
+Brechas:
+
+- Alinear nombres de body: `correo` vs `email`.
+- Definir si auth local debe usar PostgreSQL o seguir como fallback en memoria.
+- Implementar logout y refresh si frontend los necesita.
+- Registrar auditoria real de accesos en `auditoria_accesos`.
+
+### 15.2 Jornadas laborales
+
+Endpoints propuestos:
+
+- `GET /jornadas/resumen`
+- `GET /jornadas`
+- `POST /jornadas`
+- `GET /jornadas/selectores/conductores`
+- `GET /jornadas/selectores/unidades`
+- `GET /jornadas/selectores/contratos`
+- `GET /chofer/jornada-actual`
+- `POST /jornadas/{jornadaId}/iniciar-turno`
+- `POST /jornadas/{jornadaId}/finalizar-turno`
+- `GET /chofer/resumen-mensual`
+- `POST /jornadas/{jornadaId}/observaciones`
+- `GET /jornadas/{jornadaId}/observaciones`
+- `GET /jornadas/seguimiento`
+- `GET /jornadas/{jornadaId}`
+- `GET /jornadas/{jornadaId}/detalle-observacion`
+- `GET /jornadas/export.csv`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| `GET /jornadas/resumen` | Si | No | Agregacion sobre `jornadas` |
+| `GET /jornadas` | Si | Si | Actual sin filtros/paginacion completa |
+| `POST /jornadas` | Si | Si | Actual cubre registro basico |
+| Selectores | Si | Parcial | Existe `GET /unidades/disponibles`; faltan rutas especificas |
+| `GET /chofer/jornada-actual` | Si | No | Puede basarse en token + `jornadas` |
+| Iniciar/finalizar por path | Si | No con esa ruta | Existe iniciar/finalizar por body |
+| Observaciones | Parcial | No | Texto existe en `jornadas`; no historial multiple |
+| Seguimiento | Si | No | Existe `vw_seguimiento_jornadas` |
+| Export CSV | Si | No | Requiere formato de respuesta CSV |
+
+Brechas:
+
+- Implementar filtros y paginacion.
+- Definir contrato exacto para observaciones: simple texto o historial.
+- Alinear rutas REST finales con frontend.
+
+### 15.3 Contratos comerciales
+
+Endpoints propuestos:
+
+- `GET /contratos/resumen`
+- `GET /contratos/grafica`
+- `GET /contratos`
+- `GET /contratos/{contratoId}`
+- `PATCH /contratos/{contratoId}`
+- `GET /contratos/{contratoId}/tarifas`
+- `PATCH /contratos/{contratoId}/tarifas`
+- `GET /contratos/{contratoId}/unidades`
+- `POST /contratos/{contratoId}/unidades`
+- `DELETE /contratos/{contratoId}/unidades/{unidadId}`
+- `GET /contratos/{contratoId}/historial`
+- `PATCH /contratos/{contratoId}/estado`
+- `POST /contratos`
+- `POST /contratos/calcular-tarifa`
+- `GET /contratos/validar-codigo`
+- `GET /contratos/validar-ruc`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| `GET /contratos/vigentes` | Si | Si | Implementado |
+| `GET /contratos` completo | Si | No | Requiere filtros/paginacion |
+| Detalle por ID | Si | No | Tablas listas |
+| Tarifas | Si | No | Incluye `tarifa_por_tonelada` |
+| Unidades por contrato | Si | No | `contrato_unidades` listo |
+| Historial | Si | No | `contratos_historial` listo |
+| Calcular tarifa | Si | No | Puede ser logica de servicio sin escribir BD |
+
+Brechas:
+
+- Implementar repositorios/controladores.
+- Registrar cambios en `contratos_historial`.
+- Definir calculo de `total_referencial` por tipo de servicio.
+
+### 15.4 GPS e importaciones
+
+Endpoints propuestos:
+
+- `GET /gps/resumen`
+- `GET /gps/proveedores`
+- `GET /gps/plantilla`
+- `POST /gps/importaciones`
+- `GET /gps/importaciones/{importacionId}`
+- `GET /gps/importaciones/{importacionId}/errores`
+- `GET /gps/registros`
+- `GET /gps/unidades-estado`
+- `GET /gps/eventos`
+- `GET /gps/eventos/resumen`
+- `GET /gps/eventos/{eventoId}`
+- `GET /gps/tiempo-real`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| Resumen GPS | Si | No | Consulta validada |
+| Proveedores | Si | No | Usa `gps_proveedor_formatos` |
+| Plantilla | Si | No | Puede generarse desde `mapeo_columnas` |
+| Importaciones | Si | No | Tablas listas |
+| Errores de importacion | Si | No | Tabla nueva lista |
+| Registros GPS | Si | No | Indices listos |
+| Unidades estado | Si | No | Puede usar `vw_tracking_gps` + `unidades` |
+| Eventos GPS | Si | No | `gps_eventos` listo |
+| Tiempo real | Si | No | Requiere ultima ubicacion por unidad |
+
+Brechas:
+
+- Implementar parser CSV/Excel o definir si solo CSV.
+- Cuidar duplicados con `uq_gps_registros_proveedor_unidad_fecha`.
+- Usar `MOVIENDO`, `DETENIDO`, `EXCESO_VELOCIDAD` para `estado_tracking`.
+
+### 15.5 Camiones/unidades
+
+Endpoints propuestos:
+
+- `GET /camiones/{unidadId}`
+- `PATCH /camiones/{unidadId}`
+- `GET /camiones/{unidadId}/jornadas`
+- `GET /camiones/{unidadId}/gps/ultimo`
+- `GET /camiones/{unidadId}/gps/registros`
+- `GET /camiones/{unidadId}/mantenimientos`
+- `GET /camiones/resumen`
+- `GET /camiones/movimiento-resumen`
+- `GET /camiones`
+- `POST /camiones`
+- `GET /camiones/export.csv`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| `GET /camiones` simple | Parcial | Si | Usa tabla legacy `camiones` |
+| `GET /camiones/{id}` simple | Parcial | Si | Usa tabla legacy `camiones` |
+| Detalle tecnico | Si | No | Debe usar `unidades` o `vw_camiones_operativos` |
+| GPS ultimo/historial | Si | No | Usa `gps_registros` |
+| Mantenimientos | Si | No | Usa `camion_mantenimientos` |
+| Resumen | Si | No | Usa `unidades` |
+| Movimiento resumen | Si | No | Usa `gps_registros` |
+| Crear/actualizar | Si | No | Debe escribir en `unidades` y opcional legacy |
+
+Brechas:
+
+- Decidir si `camiones` queda como legacy o si endpoints nuevos usaran `unidades`.
+- Evitar duplicar logica entre `camiones` y `unidades`.
+
+### 15.6 Combustible
+
+Endpoints propuestos:
+
+- `GET /combustible/registros`
+- `POST /combustible/registros`
+- `GET /combustible/resumen`
+- `GET /combustible/registros/{registroId}`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| Lista | Si | No | Tabla lista con indices |
+| Crear | Si | No | Puede calcular rendimiento km/galon |
+| Resumen | Si | No | Consulta validada |
+| Detalle | Si | No | Tabla lista |
+
+Brechas:
+
+- Definir validaciones de kilometraje.
+- Definir si `rendimiento_km_galon` se calcula en backend o trigger.
+
+### 15.7 Auditoria
+
+Endpoints propuestos:
+
+- `GET /auditoria/accesos`
+- `GET /auditoria/accesos/resumen`
+- `GET /auditoria/accesos/export.csv`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| Lista | Si | No | Tabla lista |
+| Resumen | Si | No | Consulta validada |
+| Export CSV | Si | No | Requiere respuesta CSV |
+
+Brechas:
+
+- El flujo actual de auth no registra todos los eventos reales en `auditoria_accesos`.
+- Implementar logging de accesos exitosos/fallidos/bloqueos.
+
+### 15.8 Dashboard ejecutivo y gerencial
+
+Endpoints propuestos:
+
+- `GET /dashboard/ejecutivo/resumen`
+- `GET /dashboard/ejecutivo/alertas`
+- `GET /dashboard/ejecutivo/gps-estados`
+- `GET /dashboard/ejecutivo/camiones`
+- `GET /dashboard/ejecutivo/contratos`
+- `GET /dashboard/gerencial/resumen`
+- `GET /dashboard/gerencial/series`
+- `GET /dashboard/gerencial/operaciones`
+- `GET /dashboard/gerencial/rendimiento`
+- `GET /dashboard/gerencial/historial`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| Ejecutivo resumen | Si | No | `vw_dashboard_resumen` validada |
+| Alertas | Si | No | `vw_alertas_panel` lista |
+| GPS estados | Si | No | `gps_registros` listo |
+| Camiones | Si | No | `vw_camiones_operativos` lista |
+| Contratos | Si | No | Contratos y unidades listos |
+| Gerencial resumen | Si | No | Requiere agregaciones |
+| Series | Si | No | `jornadas` por fecha |
+| Operaciones | Si | No | Jornadas, unidades y conductores |
+| Rendimiento | Si | No | Jornadas + GPS + unidades |
+| Historial | Si | No | `vw_seguimiento_jornadas` lista |
+
+Brechas:
+
+- Implementar servicios de agregacion.
+- Definir rango de fechas y defaults.
+- Definir si se usaran vistas existentes o consultas directas.
+
+### 15.9 Catalogos
+
+Endpoints propuestos:
+
+- `GET /catalogos/conductores`
+- `GET /catalogos/unidades`
+- `GET /catalogos/contratos`
+- `GET /catalogos/proveedores-gps`
+
+Estado:
+
+| Endpoint | Base soporta | Codigo existe | Observacion |
+| --- | --- | --- | --- |
+| Conductores | Si | No | `vw_conductores_full` |
+| Unidades | Si | Parcial | Existe `/unidades/disponibles` |
+| Contratos | Si | Parcial | Existe `/contratos/vigentes` |
+| Proveedores GPS | Si | No | `gps_proveedor_formatos` |
+
+Brechas:
+
+- Crear `catalogo-services` o reutilizar servicios por dominio.
+- Evitar duplicar logica con selectores de jornadas.
+
+---
+
+## 16. Riesgos y observaciones tecnicas
+
+### 16.1 Runtime Lambda deprecado
+
+Riesgo: `sam validate` falla porque `nodejs20.x` esta deprecado desde el 2026-04-30.
+
+Impacto:
+
+- Puede bloquear CI/CD.
+- Puede bloquear nuevos despliegues si la politica de validacion se mantiene estricta.
+- Afecta a todas las Lambdas porque el runtime esta en `Globals.Function`.
+
+Accion recomendada:
+
+- Migrar a `nodejs24.x`.
+- Validar `npm test`, `sam build`, `sam validate`.
+- Probar en ambiente testing antes de produccion.
+
+### 16.2 Auth local no usa PostgreSQL
+
+Riesgo: el modo local de auth usa un arreglo en memoria.
+
+Impacto:
+
+- `POST /auth/login` local no valida usuarios reales de la tabla `usuarios`.
+- El contrato futuro de auditoria de accesos no queda completo si se mantiene asi.
+
+Accion recomendada:
+
+- Definir si el modo local seguira siendo fallback simple.
+- Si frontend necesita auth real contra BD local, implementar repositorio PostgreSQL para auth local.
+
+### 16.3 Diferencia de nombres en contrato de Auth
+
+El frontend propuesto usa:
+
+```json
+{
+  "correo": "usuario@correo.com",
+  "password": "..."
+}
+```
+
+El backend actual espera:
+
+```json
+{
+  "email": "usuario@correo.com",
+  "password": "..."
+}
+```
+
+Accion recomendada:
+
+- Aceptar ambos nombres temporalmente.
+- O acordar un contrato unico entre frontend y backend.
+
+### 16.4 `camiones` legacy vs `unidades`
+
+La base moderna usa `unidades`, pero los endpoints actuales de camiones consultan `camiones`.
+
+Impacto:
+
+- `GET /camiones` actual devuelve pocos campos.
+- Los endpoints futuros de detalle tecnico requieren `unidades`.
+
+Accion recomendada:
+
+- Reorientar endpoints nuevos de camiones hacia `unidades`/`vw_camiones_operativos`.
+- Mantener `camiones` solo como compatibilidad si frontend viejo lo necesita.
+
+### 16.5 Observaciones de jornada
+
+La tabla `jornadas` permite guardar observaciones simples.
+
+Impacto:
+
+- Sirve para `POST /jornadas/{jornadaId}/observaciones` si solo se guarda un texto actual.
+- No sirve para historial de multiples observaciones con fecha/usuario.
+
+Accion recomendada:
+
+- Si la HU exige historial real, crear una tabla `jornada_observaciones` en una migracion futura.
+- Si solo se necesita campo editable, usar `jornadas.observaciones` y `jornadas.observacion_admin`.
+
+### 16.6 Importacion GPS
+
+La base ya tiene:
+
+- Cabecera de importacion.
+- Errores por fila/campo.
+- Formatos por proveedor.
+- Unicidad para duplicados GPS.
+
+Pendiente:
+
+- Implementar parser CSV/Excel.
+- Decidir si la carga masiva sera Lambda directa, S3 + Lambda, o API con multipart.
+- Definir limites de tamano de archivo.
+
+---
+
+## 17. Comandos para reproducir validaciones
+
+### 17.1 Variables locales
+
+```powershell
+$env:DB_HOST="localhost"
+$env:DB_USER="postgres"
+$env:DB_PASSWORD="<tu password>"
+$env:DB_NAME="nanutech_local"
+$env:DB_PORT="5432"
+$env:DB_SSL_ENABLED="false"
+```
+
+### 17.2 Reiniciar base local
+
+Advertencia: comando destructivo para la base apuntada por `DB_NAME`.
+
+```powershell
+node scripts\db-init-local.mjs
+```
+
+### 17.3 Ejecutar tests
+
+```powershell
+npm test
+```
+
+### 17.4 Smoke local de auth
+
+```powershell
+node scripts\smoke-auth-local.mjs --mode=local
+```
+
+### 17.5 Build SAM
+
+```powershell
+sam build
+```
+
+### 17.6 Validate SAM
+
+```powershell
+sam validate
+```
+
+Estado actual esperado:
+
+- `sam build`: OK.
+- `sam validate`: falla hasta actualizar `Runtime: nodejs20.x`.
+
+---
+
+## 18. Orden recomendado para implementar los endpoints pendientes
+
+Orden pragmatico para evitar rehacer trabajo:
+
+1. Auth contrato final:
+   - Alinear `correo/email`.
+   - Decidir auth local con BD o Cognito.
+   - Implementar logout/refresh si se usaran.
+
+2. Catalogos/selectores:
+   - Conductores.
+   - Unidades.
+   - Contratos.
+   - Proveedores GPS.
+
+3. Jornadas:
+   - Resumen.
+   - Filtros/paginacion.
+   - Seguimiento.
+   - Detalle.
+   - Iniciar/finalizar por path.
+   - Observaciones.
+
+4. Contratos:
+   - CRUD.
+   - Tarifas.
+   - Unidades.
+   - Historial.
+   - Validaciones.
+
+5. GPS:
+   - Proveedores.
+   - Plantillas.
+   - Registros.
+   - Importaciones.
+   - Errores.
+   - Eventos.
+   - Tiempo real.
+
+6. Camiones:
+   - Migrar lectura avanzada a `unidades`.
+   - Detalle tecnico.
+   - GPS por camion.
+   - Mantenimientos.
+   - Export.
+
+7. Combustible:
+   - Registros.
+   - Resumen.
+   - Calculo de rendimiento.
+
+8. Auditoria:
+   - Lista.
+   - Resumen.
+   - Export.
+   - Integrar registros desde auth.
+
+9. Dashboards:
+   - Ejecutivo.
+   - Gerencial.
+   - Series y rendimiento.
+
+---
+
+## 19. Veredicto final
+
+La base nueva esta bien encaminada y soporta la mayoria de HUs propuestas. Los cambios de Sprint 2 y Sprint 3 relacionados con GPS, carga masiva GPS y contratos estan cubiertos a nivel de estructura:
+
+- Importaciones GPS: soportadas.
+- Errores de importacion GPS: soportados.
+- Formatos por proveedor GPS: soportados.
+- Duplicados GPS: controlados por indice unico.
+- Tarifa por tonelada: soportada.
+- Contratos con rutas, tarifas, unidades e historial: soportados.
+- Jornadas y seguimiento: soportados.
+- Dashboard inicial: soportado por vistas y agregaciones.
+
+El proyecto actual funciona localmente con los endpoints existentes. Para completar el backend de las 60-70 rutas propuestas, el trabajo pendiente es implementar servicios, controladores, repositorios y rutas por dominio, mas alinear contratos JSON con frontend.
+
+Para nube, el bloqueo actual es independiente de la base: `nodejs20.x` esta deprecado y debe migrarse a un runtime vigente, preferiblemente `nodejs24.x`, validando luego con `sam validate`.

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -2,6 +2,7 @@ export default {
   testMatch: ["**/__tests__/**/*.test.mjs"],
   testPathIgnorePatterns: [
     "/node_modules/",
+    "/.aws-sam/",
     "/__tests__/helpers/",
     "/__tests__/fixtures/",
     "/__tests__/mocks/",

--- a/scripts/db-init-local.mjs
+++ b/scripts/db-init-local.mjs
@@ -3,21 +3,8 @@ import { schemaSQL } from "../db/schema.mjs";
 import { seedSQL } from "../db/seed.mjs";
 
 const resetSQL = `
-DROP VIEW IF EXISTS vw_seguimiento_jornadas CASCADE;
-DROP TABLE IF EXISTS ubicaciones_jornada CASCADE;
-DROP TABLE IF EXISTS alertas_jornada CASCADE;
-DROP TABLE IF EXISTS jornadas CASCADE;
-DROP TABLE IF EXISTS contratos CASCADE;
-DROP TABLE IF EXISTS unidades CASCADE;
-DROP TABLE IF EXISTS usuarios CASCADE;
-DROP FUNCTION IF EXISTS fn_set_updated_at() CASCADE;
-DROP TYPE IF EXISTS tipo_registro_ubicacion CASCADE;
-DROP TYPE IF EXISTS tipo_alerta CASCADE;
-DROP TYPE IF EXISTS estado_jornada CASCADE;
-DROP TYPE IF EXISTS estado_contrato CASCADE;
-DROP TYPE IF EXISTS estado_unidad CASCADE;
-DROP TYPE IF EXISTS estado_usuario CASCADE;
-DROP TYPE IF EXISTS rol_usuario CASCADE;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
 `;
 
 const showHelp = () => {
@@ -51,7 +38,6 @@ const run = async () => {
     client = await getClient();
 
     await client.query("BEGIN");
-    await client.query("CREATE EXTENSION IF NOT EXISTS pgcrypto");
 
     if (shouldReset) {
       console.log("==> Limpiando esquema previo");

--- a/src/functions/camion-services/camionRepository.mjs
+++ b/src/functions/camion-services/camionRepository.mjs
@@ -66,7 +66,7 @@ export class CamionRepository {
         `INSERT INTO camiones (placa, marca, modelo, estado)
          VALUES ($1, $2, $3, $4)
          RETURNING id, placa, marca, modelo, estado`,
-        [placa, marca, modelo, estado || "activo"],
+        [placa, marca, modelo, estado || "disponible"],
       );
       return result.rows[0];
     } catch (error) {

--- a/src/functions/jornada-services/jornadaController.mjs
+++ b/src/functions/jornada-services/jornadaController.mjs
@@ -18,7 +18,11 @@ function parseJsonBody(event) {
 }
 
 function resolveErrorResponse(error) {
-  return errorResponse(error.message, error.statusCode || 500, {
+  const statusCode =
+    error.statusCode ||
+    (/(requerido|inv[aá]lido|validaci[oó]n)/i.test(error.message) ? 400 : 500);
+
+  return errorResponse(error.message, statusCode, {
     code: error.code || "JORNADA_ERROR",
   });
 }

--- a/src/functions/jornada-services/jornadaRepository.mjs
+++ b/src/functions/jornada-services/jornadaRepository.mjs
@@ -96,7 +96,7 @@ export class JornadaRepository {
       const query = `
         ${BASE_SELECT}
         WHERE conductor_id = $1
-          AND estado IN ('REGISTRADA', 'EN_PROCESO')
+          AND estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO')
         ORDER BY created_at DESC
         LIMIT 1;
       `;
@@ -115,7 +115,7 @@ export class JornadaRepository {
         SELECT id
         FROM jornadas
         WHERE unidad_id = $1
-          AND estado IN ('REGISTRADA', 'EN_PROCESO')
+          AND estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO')
         LIMIT 1;
       `;
       const result = await client.query(query, [unidadId]);
@@ -133,7 +133,7 @@ export class JornadaRepository {
         SELECT id
         FROM jornadas
         WHERE conductor_id = $1
-          AND estado IN ('REGISTRADA', 'EN_PROCESO')
+          AND estado IN ('REGISTRADA', 'PENDIENTE', 'EN_PROCESO')
         LIMIT 1;
       `;
       const result = await client.query(query, [conductorId]);

--- a/src/functions/jornada-services/jornadaService.mjs
+++ b/src/functions/jornada-services/jornadaService.mjs
@@ -2,7 +2,7 @@ import { JornadaRepository } from "./jornadaRepository.mjs";
 import { Jornada } from "./jornadaModel.mjs";
 import { JornadaValidator } from "../../shared/utils/validators/jornadaValidator.mjs";
 
-const ACTIVE_STATES = new Set(["REGISTRADA", "EN_PROCESO"]);
+const ACTIVE_STATES = new Set(["REGISTRADA", "PENDIENTE", "EN_PROCESO"]);
 
 function createJornadaError(message, statusCode = 400, code = "JORNADA_ERROR") {
   const error = new Error(message);
@@ -63,7 +63,7 @@ export class JornadaService {
       throw createJornadaError("La jornada no existe.", 404, "JORNADA_NOT_FOUND");
     }
 
-    // Solo se permite pasar de REGISTRADA a EN_PROCESO y la hora de inicio la fija el servidor.
+    // Solo se permite pasar de REGISTRADA/PENDIENTE a EN_PROCESO y la hora de inicio la fija el servidor.
     if (jornada.estado === "EN_PROCESO") {
       throw createJornadaError(
         "La jornada ya fue iniciada.",
@@ -80,9 +80,9 @@ export class JornadaService {
       );
     }
 
-    if (jornada.estado !== "REGISTRADA") {
+    if (!["REGISTRADA", "PENDIENTE"].includes(jornada.estado)) {
       throw createJornadaError(
-        "La jornada solo puede iniciarse desde REGISTRADA.",
+        "La jornada solo puede iniciarse desde REGISTRADA o PENDIENTE.",
         400,
         "JORNADA_INVALID_STATE",
       );

--- a/src/shared/utils/validators/camionValidator.mjs
+++ b/src/shared/utils/validators/camionValidator.mjs
@@ -32,8 +32,19 @@ export class CamionValidator {
   }
 
   static validateEstado(estado) {
-    if (!estado) return "activo";
-    const estadosValidos = ["activo", "inactivo", "mantenimiento"];
+    if (!estado) return "disponible";
+    const estadosValidos = [
+      "activo",
+      "active",
+      "available",
+      "disponible",
+      "en_uso",
+      "en_jornada",
+      "en_auxilio",
+      "inactivo",
+      "mantenimiento",
+      "maintenance",
+    ];
     if (!estadosValidos.includes(estado.toLowerCase())) {
       throw new Error(ERROR_MESSAGES.CAMION_ESTADO_INVALID);
     }

--- a/src/shared/utils/validators/jornadaValidator.mjs
+++ b/src/shared/utils/validators/jornadaValidator.mjs
@@ -1,4 +1,4 @@
-const VALID_CREATE_STATES = new Set(["REGISTRADA", "EN_PROCESO"]);
+const VALID_CREATE_STATES = new Set(["REGISTRADA", "PENDIENTE", "EN_PROCESO"]);
 
 function requireString(value, fieldName) {
   if (value === undefined || value === null || `${value}`.trim() === "") {
@@ -45,7 +45,7 @@ export class JornadaValidator {
       fecha_jornada: normalizeOptionalString(data.fecha_jornada),
       origen: normalizeOptionalString(data.origen),
       destino: normalizeOptionalString(data.destino),
-      km_recorridos: normalizeOptionalNumber(data.km_recorridos, "km_recorridos"),
+      km_recorridos: normalizeOptionalNumber(data.km_recorridos, "km_recorridos") ?? 0,
       observaciones: normalizeOptionalString(data.observaciones),
       estado,
     };


### PR DESCRIPTION
## Resumen

Se actualiza la base de datos del backend para soportar nuevas estructuras relacionadas con GPS, importaciones, contratos y datos de prueba.

## Cambios principales

- Actualización de `schema.sql`, `schema.mjs`, `seed.sql` y `seed.mjs`.
- Sincronización de migración y seed del proyecto.
- Se agrega soporte para errores de importación GPS.
- Se agrega soporte para formatos de proveedores GPS.
- Se agrega tarifa por tonelada en contratos.
- Se agrega control de duplicados en registros GPS.
- Se actualizan datos de prueba para validar contratos, jornadas, GPS e importaciones.
- Se realizan ajustes mínimos en validadores/repositorios para mantener funcionando los endpoints actuales con la nueva base.

## Validación

- `npm test` OK.
- `sam build` OK.
- Probado localmente contra PostgreSQL.
- Se verificaron endpoints actuales principales contra la nueva base local.

## Nota

`sam validate` puede reportar advertencia/error por `nodejs20.x` deprecado (obsoleto) en `template.yaml`. No se modifica en este PR porque corresponde coordinarlo con nube/infraestructura.
