### PR TITLE
HU11: panel-monitoreo-gestion-camiones

### DIFF
--- a/__tests__/unit/camion-services/camionController.hu11.test.mjs
+++ b/__tests__/unit/camion-services/camionController.hu11.test.mjs
@@ -1,0 +1,130 @@
+import { jest } from "@jest/globals";
+
+const mockCreateCamion = jest.fn();
+const mockGetPanel = jest.fn();
+const mockExportCsv = jest.fn();
+
+jest.unstable_mockModule(
+  "../../../src/functions/camion-services/camionService.mjs",
+  () => ({
+    CamionService: jest.fn().mockImplementation(() => ({
+      createCamion: mockCreateCamion,
+      getPanel: mockGetPanel,
+      exportCsv: mockExportCsv,
+    })),
+  }),
+);
+
+const {
+  createCamionController,
+  getPanelCamionesController,
+  exportCamionesCsvController,
+} = await import("../../../src/functions/camion-services/camionController.mjs");
+
+describe("HU11 - CamionController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("createCamionController debe registrar camión HU11 y responder 201", async () => {
+    mockCreateCamion.mockResolvedValue({
+      id: "unidad-001",
+      placa: "XYZ-999",
+      modelo: "FH16",
+      estado: "DISPONIBLE",
+      confirmacion: {
+        message: "¡Camión registrado con éxito!",
+        placa: "XYZ-999",
+        modelo: "FH16",
+      },
+    });
+
+    const event = {
+      body: JSON.stringify({
+        placa: "XYZ-999",
+        marca: "Volvo",
+        modelo: "FH16",
+        anio: 2024,
+        capacidad_ton: 20,
+        vin: "VINXYZ999",
+        color: "Blanco",
+        combustible: "DIESEL",
+        gps: true,
+      }),
+    };
+
+    const response = await createCamionController(event);
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data.estado).toBe("DISPONIBLE");
+    expect(body.data.confirmacion.message).toBe("¡Camión registrado con éxito!");
+  });
+
+  test("createCamionController debe responder 400 si hay error de validación", async () => {
+    mockCreateCamion.mockRejectedValue(
+      new Error("El campo placa es obligatorio"),
+    );
+
+    const response = await createCamionController({
+      body: JSON.stringify({}),
+    });
+
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.message).toContain("placa");
+  });
+
+  test("getPanelCamionesController debe devolver panel", async () => {
+    mockGetPanel.mockResolvedValue({
+      resumen: {
+        total_camiones: 4,
+        en_uso: 1,
+        disponibles: 2,
+        mantenimiento: 1,
+      },
+      grafica_movimiento: {
+        horas_movimiento: 6,
+        horas_detenido: 3,
+        porcentaje_movimiento: 66.67,
+        porcentaje_detenido: 33.33,
+      },
+      camiones: [],
+    });
+
+    const response = await getPanelCamionesController({
+      queryStringParameters: {
+        estado: "DISPONIBLE",
+      },
+    });
+
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.resumen.total_camiones).toBe(4);
+    expect(mockGetPanel).toHaveBeenCalledWith({
+      estado: "DISPONIBLE",
+    });
+  });
+
+  test("exportCamionesCsvController debe devolver text/csv", async () => {
+    mockExportCsv.mockResolvedValue(
+      '"ID","Placa","Marca","Modelo","Año","Capacidad (ton)","Estado","VIN","Color","GPS","Kilometraje","Fecha de Registro","Último Mantenimiento","Próximo Mantenimiento"',
+    );
+
+    const response = await exportCamionesCsvController({
+      queryStringParameters: {
+        estado: "DISPONIBLE",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["Content-Type"]).toContain("text/csv");
+    expect(response.body).toContain("Placa");
+    expect(response.body).toContain("Capacidad (ton)");
+  });
+});

--- a/__tests__/unit/camion-services/camionService.hu11.test.mjs
+++ b/__tests__/unit/camion-services/camionService.hu11.test.mjs
@@ -1,0 +1,182 @@
+import { jest } from "@jest/globals";
+import { CamionService } from "../../../src/functions/camion-services/camionService.mjs";
+
+describe("HU11 - CamionService", () => {
+  let service;
+
+  beforeEach(() => {
+    service = new CamionService();
+
+    service.repository = {
+      getByPlaca: jest.fn(),
+      create: jest.fn(),
+      getByPlacaHu11: jest.fn(),
+      getByVinHu11: jest.fn(),
+      createHu11: jest.fn(),
+      getPanelHu11: jest.fn(),
+      exportCsvHu11: jest.fn(),
+    };
+  });
+
+  const camionHu11Valido = {
+    placa: "xyz-999",
+    marca: "Volvo",
+    modelo: "FH16",
+    anio: 2024,
+    capacidad_ton: 20,
+    vin: "vinxyz999",
+    color: "Blanco",
+    combustible: "DIESEL",
+    gps: true,
+  };
+
+  test("debe validar payload HU11 y normalizar campos", () => {
+    const result = service.validateCreateCamionHu11(camionHu11Valido);
+
+    expect(result.placa).toBe("XYZ-999");
+    expect(result.vin).toBe("VINXYZ999");
+    expect(result.estado).toBe("DISPONIBLE");
+    expect(result.gps_habilitado).toBe(true);
+    expect(result.capacidad_ton).toBe(20);
+    expect(result.tipo_combustible).toBe("DIESEL");
+  });
+
+  test("debe rechazar placa vacía", () => {
+    expect(() =>
+      service.validateCreateCamionHu11({
+        ...camionHu11Valido,
+        placa: "",
+      }),
+    ).toThrow("placa");
+  });
+
+  test("debe rechazar año inválido", () => {
+    expect(() =>
+      service.validateCreateCamionHu11({
+        ...camionHu11Valido,
+        anio: 1800,
+      }),
+    ).toThrow("Año fuera del rango permitido");
+  });
+
+  test("debe rechazar capacidad cero", () => {
+    expect(() =>
+      service.validateCreateCamionHu11({
+        ...camionHu11Valido,
+        capacidad_ton: 0,
+      }),
+    ).toThrow("La capacidad debe ser mayor a 0 toneladas");
+  });
+
+  test("debe rechazar VIN vacío", () => {
+    expect(() =>
+      service.validateCreateCamionHu11({
+        ...camionHu11Valido,
+        vin: "",
+      }),
+    ).toThrow("vin");
+  });
+
+  test("debe registrar camión HU11 correctamente usando createCamion", async () => {
+    service.repository.getByPlacaHu11.mockResolvedValue(null);
+    service.repository.getByVinHu11.mockResolvedValue(null);
+    service.repository.createHu11.mockResolvedValue({
+      id: "unidad-001",
+      placa: "XYZ-999",
+      marca: "Volvo",
+      modelo: "FH16",
+      anio: 2024,
+      capacidad_ton: 20,
+      estado: "DISPONIBLE",
+      gps_habilitado: true,
+      vin: "VINXYZ999",
+      color: "Blanco",
+      tipo_combustible: "DIESEL",
+      kilometraje_actual: 0,
+    });
+
+    const result = await service.createCamion(camionHu11Valido);
+
+    expect(service.repository.getByPlacaHu11).toHaveBeenCalledWith("XYZ-999");
+    expect(service.repository.getByVinHu11).toHaveBeenCalledWith("VINXYZ999");
+    expect(service.repository.createHu11).toHaveBeenCalled();
+    expect(result.estado).toBe("DISPONIBLE");
+    expect(result.confirmacion.message).toBe("¡Camión registrado con éxito!");
+    expect(result.confirmacion.placa).toBe("XYZ-999");
+    expect(result.confirmacion.modelo).toBe("FH16");
+  });
+
+  test("debe rechazar placa duplicada en HU11 usando createCamion", async () => {
+    service.repository.getByPlacaHu11.mockResolvedValue({
+      id: "unidad-existente",
+      placa: "XYZ-999",
+    });
+
+    await expect(service.createCamion(camionHu11Valido)).rejects.toThrow(
+      "Ya existe un camión con esta placa",
+    );
+
+    expect(service.repository.createHu11).not.toHaveBeenCalled();
+  });
+
+  test("debe rechazar VIN duplicado en HU11 usando createCamion", async () => {
+    service.repository.getByPlacaHu11.mockResolvedValue(null);
+    service.repository.getByVinHu11.mockResolvedValue({
+      id: "unidad-existente",
+      vin: "VINXYZ999",
+    });
+
+    await expect(service.createCamion(camionHu11Valido)).rejects.toThrow(
+      "Ya existe un camión con este VIN",
+    );
+
+    expect(service.repository.createHu11).not.toHaveBeenCalled();
+  });
+
+  test("debe obtener panel HU11 desde repository", async () => {
+    const panelMock = {
+      resumen: {
+        total_camiones: 3,
+        en_uso: 1,
+        disponibles: 1,
+        mantenimiento: 1,
+      },
+      grafica_movimiento: {
+        horas_movimiento: 8,
+        horas_detenido: 2,
+        porcentaje_movimiento: 80,
+        porcentaje_detenido: 20,
+      },
+      camiones: [],
+    };
+
+    service.repository.getPanelHu11.mockResolvedValue(panelMock);
+
+    const result = await service.getPanel({
+      estado: "DISPONIBLE",
+    });
+
+    expect(service.repository.getPanelHu11).toHaveBeenCalledWith({
+      estado: "DISPONIBLE",
+    });
+    expect(result.resumen.total_camiones).toBe(3);
+    expect(result.grafica_movimiento.porcentaje_movimiento).toBe(80);
+  });
+
+  test("debe exportar CSV HU11 desde repository", async () => {
+    const csvMock =
+      '"ID","Placa","Marca","Modelo","Año","Capacidad (ton)","Estado","VIN","Color","GPS","Kilometraje","Fecha de Registro","Último Mantenimiento","Próximo Mantenimiento"';
+
+    service.repository.exportCsvHu11.mockResolvedValue(csvMock);
+
+    const result = await service.exportCsv({
+      estado: "DISPONIBLE",
+    });
+
+    expect(service.repository.exportCsvHu11).toHaveBeenCalledWith({
+      estado: "DISPONIBLE",
+    });
+    expect(result).toContain("Placa");
+    expect(result).toContain("Capacidad (ton)");
+  });
+});

--- a/src/functions/camion-services/camionController.mjs
+++ b/src/functions/camion-services/camionController.mjs
@@ -47,3 +47,70 @@ export const getCamionByIdController = async (event) => {
     return errorResponse(error.message, 500);
   }
 };
+
+export const createCamionController = async (event) => {
+  try {
+    const body = JSON.parse(event.body || "{}");
+
+    const camionService = new CamionService();
+    const camion = await camionService.createCamion(body);
+
+    return successResponse(
+      camion,
+      "Camión registrado exitosamente.",
+      201
+    );
+  } catch (error) {
+    console.error("Error en createCamionController:", error);
+
+    const statusCode =
+      /duplicad|existe|obligatorio|requerid|inválid|invalido|rango|capacidad|vin|placa/i.test(
+        error.message
+      )
+        ? 400
+        : 500;
+
+    return errorResponse(error.message, statusCode);
+  }
+};
+
+export const getPanelCamionesController = async (event) => {
+  try {
+    const camionService = new CamionService();
+
+    const panel = await camionService.getPanel(
+      event.queryStringParameters || {}
+    );
+
+    return successResponse(
+      panel,
+      "Panel de camiones obtenido exitosamente."
+    );
+  } catch (error) {
+    console.error("Error en getPanelCamionesController:", error);
+    return errorResponse(error.message, 500);
+  }
+};
+
+export const exportCamionesCsvController = async (event) => {
+  try {
+    const camionService = new CamionService();
+
+    const csv = await camionService.exportCsv(
+      event.queryStringParameters || {}
+    );
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": 'attachment; filename="camiones.csv"',
+        "Access-Control-Allow-Origin": "*",
+      },
+      body: csv,
+    };
+  } catch (error) {
+    console.error("Error en exportCamionesCsvController:", error);
+    return errorResponse(error.message, 500);
+  }
+};

--- a/src/functions/camion-services/camionHandler.mjs
+++ b/src/functions/camion-services/camionHandler.mjs
@@ -2,11 +2,17 @@
 import {
   getAllCamionesController,
   getCamionByIdController,
+  createCamionController,
+  getPanelCamionesController,
+  exportCamionesCsvController,
 } from "./camionController.mjs";
 
 const routes = {
   "GET /camiones": getAllCamionesController,
   "GET /camiones/{id}": getCamionByIdController,
+  "POST /camiones": createCamionController,
+  "GET /camiones/panel": getPanelCamionesController,
+  "GET /camiones/exportar/csv": exportCamionesCsvController,
 };
 
 export const handler = async (event) => {

--- a/src/functions/camion-services/camionRepository.mjs
+++ b/src/functions/camion-services/camionRepository.mjs
@@ -105,6 +105,253 @@ export class CamionRepository {
       throw new Error(`Error al eliminar: ${error.message}`);
     }
   }
+  
+  async getByPlacaHu11(placa) {
+  const result = await db.query(
+    `
+    SELECT id, placa
+    FROM unidades
+    WHERE UPPER(placa) = UPPER($1)
+    LIMIT 1
+    `,
+    [placa]
+  );
+
+  return result.rows[0] || null;
+}
+
+async getByVinHu11(vin) {
+  const result = await db.query(
+    `
+    SELECT id, placa, vin
+    FROM unidades
+    WHERE UPPER(vin) = UPPER($1)
+    LIMIT 1
+    `,
+    [vin]
+  );
+
+  return result.rows[0] || null;
+}
+
+async createHu11(data) {
+  const result = await db.query(
+    `
+    INSERT INTO unidades (
+      placa,
+      marca,
+      modelo,
+      anio,
+      capacidad_ton,
+      estado,
+      gps_habilitado,
+      vin,
+      color,
+      tipo_combustible,
+      fecha_registro,
+      ultima_fecha_mantenimiento,
+      proxima_fecha_mantenimiento,
+      kilometraje_actual,
+      activo
+    )
+    VALUES (
+      $1, $2, $3, $4, $5,
+      'DISPONIBLE',
+      $6, $7, $8, $9,
+      $10, $11, $12, $13,
+      TRUE
+    )
+    RETURNING
+      id,
+      placa,
+      marca,
+      modelo,
+      anio,
+      capacidad_ton,
+      estado,
+      gps_habilitado,
+      vin,
+      color,
+      tipo_combustible,
+      fecha_registro,
+      ultima_fecha_mantenimiento,
+      proxima_fecha_mantenimiento,
+      kilometraje_actual
+    `,
+    [
+      data.placa,
+      data.marca,
+      data.modelo,
+      data.anio,
+      data.capacidad_ton,
+      data.gps_habilitado,
+      data.vin,
+      data.color,
+      data.tipo_combustible,
+      data.fecha_registro,
+      data.ultima_fecha_mantenimiento,
+      data.proxima_fecha_mantenimiento,
+      data.kilometraje_actual,
+    ]
+  );
+
+  return result.rows[0];
+}
+
+async getPanelHu11(filters = {}) {
+  const conditions = ["u.activo = TRUE"];
+  const params = [];
+
+  if (filters.placa) {
+    params.push(`%${String(filters.placa).trim()}%`);
+    conditions.push(`u.placa ILIKE $${params.length}`);
+  }
+
+  if (filters.estado && String(filters.estado).toUpperCase() !== "TODOS") {
+    let estado = String(filters.estado).trim().toUpperCase();
+
+    if (estado === "EN_USO") {
+      estado = "EN_JORNADA";
+    }
+
+    params.push(estado);
+    conditions.push(`u.estado = $${params.length}`);
+  }
+
+  const whereClause = `WHERE ${conditions.join(" AND ")}`;
+
+  const result = await db.query(
+    `
+    WITH base AS (
+      SELECT
+        u.id,
+        u.placa,
+        u.marca,
+        u.modelo,
+        u.anio,
+        u.capacidad_ton,
+        u.estado,
+        u.vin,
+        u.color,
+        u.gps_habilitado,
+        u.kilometraje_actual,
+        u.fecha_registro,
+        u.ultima_fecha_mantenimiento,
+        u.proxima_fecha_mantenimiento,
+        COALESCE(gps.horas_movimiento, 0)::float AS horas_movimiento,
+        COALESCE(gps.horas_detenido, 0)::float AS horas_detenido,
+        (
+          COALESCE(gps.horas_movimiento, 0) +
+          COALESCE(gps.horas_detenido, 0)
+        )::float AS horas_totales,
+        COALESCE(gps.kilometros_totales, u.kilometraje_actual, 0)::float AS kilometros_totales
+      FROM unidades u
+      LEFT JOIN (
+        SELECT
+          unidad_id,
+          ROUND((COUNT(*) FILTER (WHERE velocidad_kmh > 5) * 0.5)::numeric, 2) AS horas_movimiento,
+          ROUND((COUNT(*) FILTER (WHERE velocidad_kmh <= 5 OR velocidad_kmh IS NULL) * 0.5)::numeric, 2) AS horas_detenido,
+          MAX(odometro_km) AS kilometros_totales
+        FROM gps_registros
+        GROUP BY unidad_id
+      ) gps ON gps.unidad_id = u.id
+      ${whereClause}
+    )
+    SELECT
+      COALESCE(json_agg(base ORDER BY placa), '[]'::json) AS camiones,
+      COUNT(*)::int AS total_camiones,
+      COUNT(*) FILTER (WHERE estado = 'EN_JORNADA')::int AS en_uso,
+      COUNT(*) FILTER (WHERE estado = 'DISPONIBLE')::int AS disponibles,
+      COUNT(*) FILTER (WHERE estado = 'MANTENIMIENTO')::int AS mantenimiento,
+      COALESCE(SUM(horas_movimiento), 0)::float AS horas_movimiento,
+      COALESCE(SUM(horas_detenido), 0)::float AS horas_detenido
+    FROM base
+    `,
+    params
+  );
+
+  const row = result.rows[0];
+
+  const horasMovimiento = Number(row.horas_movimiento || 0);
+  const horasDetenido = Number(row.horas_detenido || 0);
+  const horasTotales = horasMovimiento + horasDetenido;
+
+  return {
+    resumen: {
+      total_camiones: Number(row.total_camiones || 0),
+      en_uso: Number(row.en_uso || 0),
+      disponibles: Number(row.disponibles || 0),
+      mantenimiento: Number(row.mantenimiento || 0),
+    },
+    grafica_movimiento: {
+      horas_movimiento: horasMovimiento,
+      horas_detenido: horasDetenido,
+      porcentaje_movimiento:
+        horasTotales > 0
+          ? Number(((horasMovimiento / horasTotales) * 100).toFixed(2))
+          : 0,
+      porcentaje_detenido:
+        horasTotales > 0
+          ? Number(((horasDetenido / horasTotales) * 100).toFixed(2))
+          : 0,
+    },
+    camiones: row.camiones || [],
+  };
+}
+
+async exportCsvHu11(filters = {}) {
+  const panel = await this.getPanelHu11(filters);
+  const camiones = panel.camiones || [];
+
+  const headers = [
+    "ID",
+    "Placa",
+    "Marca",
+    "Modelo",
+    "Año",
+    "Capacidad (ton)",
+    "Estado",
+    "VIN",
+    "Color",
+    "GPS",
+    "Kilometraje",
+    "Fecha de Registro",
+    "Último Mantenimiento",
+    "Próximo Mantenimiento",
+  ];
+
+  const escapeCsv = (value) => {
+    if (value === null || value === undefined) {
+      return "";
+    }
+
+    const text = String(value).replaceAll('"', '""');
+    return `"${text}"`;
+  };
+
+  const rows = camiones.map((camion) => [
+    camion.id,
+    camion.placa,
+    camion.marca,
+    camion.modelo,
+    camion.anio,
+    camion.capacidad_ton,
+    camion.estado,
+    camion.vin,
+    camion.color,
+    camion.gps_habilitado ? "SI" : "NO",
+    camion.kilometros_totales ?? camion.kilometraje_actual ?? 0,
+    camion.fecha_registro,
+    camion.ultima_fecha_mantenimiento,
+    camion.proxima_fecha_mantenimiento,
+  ]);
+
+  return [
+    headers.map(escapeCsv).join(","),
+    ...rows.map((row) => row.map(escapeCsv).join(",")),
+  ].join("\n");
+}
+
 }
 
 export default new CamionRepository();

--- a/src/functions/camion-services/camionService.mjs
+++ b/src/functions/camion-services/camionService.mjs
@@ -34,16 +34,31 @@ export class CamionService {
 
   async createCamion(camionData) {
     try {
+      const isHu11Payload =
+        camionData.anio !== undefined ||
+        camionData.capacidad_ton !== undefined ||
+        camionData.capacidadTon !== undefined ||
+        camionData.vin !== undefined ||
+        camionData.color !== undefined ||
+        camionData.combustible !== undefined ||
+        camionData.gps !== undefined;
+
+      if (isHu11Payload) {
+        return this.createCamionHu11(camionData);
+      }
+
       const validatedData = CamionValidator.validateCreateCamion(camionData);
 
-      // Verificar si placa ya existe
       const existingByPlaca = await this.repository.getByPlaca(
         validatedData.placa,
       );
-      if (existingByPlaca) throw new Error(ERROR_MESSAGES.CAMION_PLACA_EXISTS);
+
+      if (existingByPlaca) {
+        throw new Error(ERROR_MESSAGES.CAMION_PLACA_EXISTS);
+      }
 
       const newCamion = new Camion(
-        null, // id es SERIAL, lo genera la BD
+        null,
         validatedData.placa,
         validatedData.marca,
         validatedData.modelo,
@@ -54,6 +69,42 @@ export class CamionService {
       return Camion.fromDatabase(created);
     } catch (error) {
       console.error("Error en createCamion service:", error);
+      throw error;
+    }
+  }
+
+  async createCamionHu11(camionData) {
+    try {
+      const validatedData = this.validateCreateCamionHu11(camionData);
+
+      const existingByPlaca = await this.repository.getByPlacaHu11(
+        validatedData.placa,
+      );
+
+      if (existingByPlaca) {
+        throw new Error("Ya existe un camión con esta placa");
+      }
+
+      const existingByVin = await this.repository.getByVinHu11(
+        validatedData.vin,
+      );
+
+      if (existingByVin) {
+        throw new Error("Ya existe un camión con este VIN");
+      }
+
+      const created = await this.repository.createHu11(validatedData);
+
+      return {
+        ...created,
+        confirmacion: {
+          message: "¡Camión registrado con éxito!",
+          placa: created.placa,
+          modelo: created.modelo,
+        },
+      };
+    } catch (error) {
+      console.error("Error en createCamionHu11 service:", error);
       throw error;
     }
   }
@@ -71,6 +122,7 @@ export class CamionService {
         const existingByPlaca = await this.repository.getByPlaca(
           validatedUpdates.placa,
         );
+
         if (existingByPlaca && existingByPlaca.id !== validatedId) {
           throw new Error(ERROR_MESSAGES.CAMION_PLACA_EXISTS);
         }
@@ -80,6 +132,7 @@ export class CamionService {
         validatedId,
         validatedUpdates,
       );
+
       return Camion.fromDatabase(updated);
     } catch (error) {
       console.error("Error en updateCamion service:", error);
@@ -100,5 +153,103 @@ export class CamionService {
       console.error("Error en deleteCamion service:", error);
       throw error;
     }
+  }
+
+  async getPanel(filters = {}) {
+    return this.repository.getPanelHu11(filters);
+  }
+
+  async exportCsv(filters = {}) {
+    return this.repository.exportCsvHu11(filters);
+  }
+
+  validateCreateCamionHu11(data = {}) {
+    const requiredFields = [
+      "placa",
+      "marca",
+      "modelo",
+      "anio",
+      "capacidad_ton",
+      "vin",
+      "color",
+      "combustible",
+      "gps",
+    ];
+
+    for (const field of requiredFields) {
+      if (
+        data[field] === undefined ||
+        data[field] === null ||
+        data[field] === ""
+      ) {
+        throw new Error(`El campo ${field} es obligatorio`);
+      }
+    }
+
+    const placa = String(data.placa).trim().toUpperCase();
+
+    if (!placa) {
+      throw new Error("La placa no puede estar vacía");
+    }
+
+    const marca = String(data.marca).trim();
+
+    if (!marca) {
+      throw new Error("La marca no puede estar vacía");
+    }
+
+    const modelo = String(data.modelo).trim();
+
+    if (!modelo) {
+      throw new Error("El modelo no puede estar vacío");
+    }
+
+    const anio = Number(data.anio);
+    const currentYear = new Date().getFullYear();
+
+    if (!Number.isInteger(anio) || anio < 1990 || anio > currentYear + 1) {
+      throw new Error("Año fuera del rango permitido");
+    }
+
+    const capacidadTon = Number(data.capacidad_ton);
+
+    if (Number.isNaN(capacidadTon) || capacidadTon <= 0) {
+      throw new Error("La capacidad debe ser mayor a 0 toneladas");
+    }
+
+    const vin = String(data.vin).trim().toUpperCase();
+
+    if (!vin) {
+      throw new Error("El VIN es obligatorio");
+    }
+
+    const color = String(data.color).trim();
+
+    if (!color) {
+      throw new Error("El color es obligatorio");
+    }
+
+    const tipoCombustible = String(data.combustible).trim().toUpperCase();
+
+    if (!tipoCombustible) {
+      throw new Error("El combustible es obligatorio");
+    }
+
+    return {
+      placa,
+      marca,
+      modelo,
+      anio,
+      capacidad_ton: capacidadTon,
+      vin,
+      color,
+      tipo_combustible: tipoCombustible,
+      gps_habilitado: Boolean(data.gps),
+      estado: "DISPONIBLE",
+      kilometraje_actual: Number(data.kilometraje_actual || 0),
+      fecha_registro: new Date().toISOString().slice(0, 10),
+      ultima_fecha_mantenimiento: data.ultimo_mantenimiento || null,
+      proxima_fecha_mantenimiento: data.proximo_mantenimiento || null,
+    };
   }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -174,6 +174,24 @@ Resources:
             RestApiId: !Ref NanutechApi
             Path: /camiones/{id}
             Method: GET
+        CreateCamion:
+          Type: Api
+          Properties:
+            RestApiId: !Ref NanutechApi
+            Path: /camiones
+            Method: POST
+        GetPanelCamiones:
+          Type: Api
+          Properties:
+            RestApiId: !Ref NanutechApi
+            Path: /camiones/panel
+            Method: GET
+        ExportCamionesCsv:
+          Type: Api
+          Properties:
+            RestApiId: !Ref NanutechApi
+            Path: /camiones/exportar/csv
+            Method: GET
       Tags:
         Environment: !Ref StageName
         Servicio: camion


### PR DESCRIPTION
## HU11 - Panel de Monitoreo y Gestión de Camiones

### Resumen
Se implementa la funcionalidad backend para el panel de monitoreo y gestión de camiones, permitiendo visualizar indicadores de unidades, movimiento/detenido, registrar camiones con campos completos y exportar información en CSV.

### Cambios realizados
- Se extendió el módulo `camion-services` sin reemplazar el CRUD existente.
- Se mantuvo compatibilidad con los endpoints antiguos de camiones.
- Se agregó soporte para registro de camiones con campos completos de HU11.
- Se agregó validación de placa duplicada.
- Se agregó validación de VIN duplicado.
- Se agregó validación de año permitido.
- Se agregó validación de capacidad mayor a cero.
- Se agregó cálculo de movimiento y detenido usando registros GPS.
- Se agregó endpoint de panel de monitoreo.
- Se agregó endpoint de exportación CSV.
- Se agregaron tests unitarios para service y controller de HU11.

### Endpoints implementados o extendidos
- `GET /camiones`
- `GET /camiones/{id}`
- `POST /camiones`
- `GET /camiones/panel`
- `GET /camiones/exportar/csv`

### Criterios de aceptación cubiertos
- Visualización del total de camiones.
- Visualización de camiones en uso.
- Visualización de camiones disponibles.
- Visualización de camiones en mantenimiento.
- Cálculo de movimiento vs detenido usando GPS.
- Criterio de movimiento cuando `velocidad_kmh > 5`.
- Criterio de detenido cuando `velocidad_kmh <= 5`.
- Listado de camiones para el grid del panel.
- Filtro por placa.
- Filtro por estado.
- Registro de camión con placa, marca, modelo, año, capacidad, VIN, color, combustible y GPS.
- Estado inicial `DISPONIBLE` al registrar un camión.
- Rechazo por placa duplicada.
- Rechazo por VIN duplicado.
- Rechazo por año inválido.
- Rechazo por capacidad igual o menor a cero.
- Exportación CSV compatible con Excel.
- Exportación CSV respetando filtros aplicados.

### Compatibilidad
Se conservaron los métodos existentes del CRUD de camiones:
- `getAll`
- `getById`
- `create`
- `update`
- `delete`

La lógica HU11 se agregó de forma incremental usando métodos nuevos en repository y detección de payload completo en service, para evitar romper funcionalidades anteriores usadas por otros módulos o compañeros.

### Pruebas realizadas
- `npm test`: OK.
- `sam build`: OK.
- Pruebas manuales realizadas sobre:
  - `/camiones`
  - `/camiones/{id}`
  - `/camiones/panel`
  - `/camiones/panel?placa=...`
  - `/camiones/panel?estado=...`
  - `POST /camiones`
  - `/camiones/exportar/csv`
  - `/camiones/exportar/csv?estado=...`
  - `/camiones/exportar/csv?placa=...`