### PR TITLE
feat(HU05): Seguimiento de Jornadas - GET /jornadas con filtros, duración total y exportar CSV

### DIFF
--- a/__tests__/unit/jornada-services-test/jornadaController.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaController.test.mjs
@@ -5,15 +5,19 @@ jest.unstable_mockModule(
   () => ({
     JornadaService: jest.fn().mockImplementation(() => ({
       createJornada: jest.fn(),
+      getAllJornadas: jest.fn(),
       getCurrentJornada: jest.fn(),
       startTurn: jest.fn(),
       finishTurn: jest.fn(),
+      generateCsv: jest.fn(),
     })),
   }),
 );
 
 const {
   createJornadaController,
+  getAllJornadasController,
+  exportCsvController,
   getCurrentJornadaController,
   startTurnController,
   finishTurnController,
@@ -104,5 +108,99 @@ describe("JornadaController", () => {
     });
 
     expect(result.statusCode).toBe(400);
+  });
+
+  test("obtiene todas las jornadas sin filtros", async () => {
+    JornadaService.mockImplementation(() => ({
+      getAllJornadas: jest.fn().mockResolvedValue([
+        { id: "jor-1", estado: "COMPLETADA", duracion_total: "08:00", tiene_observaciones: false },
+      ]),
+    }));
+
+    const result = await getAllJornadasController({ queryStringParameters: null });
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+  });
+
+  test("obtiene jornadas filtradas por texto de búsqueda", async () => {
+    const mockGetAll = jest.fn().mockResolvedValue([]);
+    JornadaService.mockImplementation(() => ({ getAllJornadas: mockGetAll }));
+
+    await getAllJornadasController({
+      queryStringParameters: { q: "ABC" },
+    });
+
+    expect(mockGetAll).toHaveBeenCalledWith(
+      expect.objectContaining({ q: "ABC" }),
+    );
+  });
+
+  test("obtiene jornadas filtradas por conductor y rango de fechas", async () => {
+    const mockGetAll = jest.fn().mockResolvedValue([]);
+    JornadaService.mockImplementation(() => ({ getAllJornadas: mockGetAll }));
+
+    await getAllJornadasController({
+      queryStringParameters: {
+        conductor_id: "cond-1",
+        fecha_desde: "2026-01-01",
+        fecha_hasta: "2026-04-30",
+      },
+    });
+
+    expect(mockGetAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conductor_id: "cond-1",
+        fecha_desde: "2026-01-01",
+        fecha_hasta: "2026-04-30",
+      }),
+    );
+  });
+
+  test("exporta jornadas como CSV sin filtros", async () => {
+    JornadaService.mockImplementation(() => ({
+      generateCsv: jest.fn().mockResolvedValue(
+        "ID Jornada,Fecha,Conductor,Placa del Camion,Contrato,Hora Inicio,Hora Fin,Duracion Total,KM Recorridos,Estado,Observaciones\njor-1,2026-04-08,Juan Perez,ABC-123,CON-001,,,,150,COMPLETADA,",
+      ),
+    }));
+
+    const result = await exportCsvController({ queryStringParameters: null });
+
+    expect(result.statusCode).toBe(200);
+    expect(result.headers["Content-Type"]).toBe("text/csv");
+    expect(result.headers["Content-Disposition"]).toContain("jornadas.csv");
+    expect(result.body).toContain("ID Jornada");
+  });
+
+  test("exporta jornadas con filtros aplicados", async () => {
+    const mockGenerateCsv = jest.fn().mockResolvedValue("ID Jornada,...\n");
+    JornadaService.mockImplementation(() => ({ generateCsv: mockGenerateCsv }));
+
+    await exportCsvController({
+      queryStringParameters: { fecha_desde: "2026-04-01", fecha_hasta: "2026-04-30" },
+    });
+
+    expect(mockGenerateCsv).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fecha_desde: "2026-04-01",
+        fecha_hasta: "2026-04-30",
+      }),
+    );
+  });
+
+  test("devuelve error controlado cuando falla la exportación CSV", async () => {
+    JornadaService.mockImplementation(() => ({
+      generateCsv: jest.fn().mockRejectedValue({
+        message: "Error de base de datos.",
+        statusCode: 500,
+        code: "DB_ERROR",
+      }),
+    }));
+
+    const result = await exportCsvController({ queryStringParameters: null });
+
+    expect(result.statusCode).toBe(500);
   });
 });

--- a/__tests__/unit/jornada-services-test/jornadaHandler.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaHandler.test.mjs
@@ -4,7 +4,8 @@ jest.unstable_mockModule(
   "../../../src/functions/jornada-services/jornadaController.mjs",
   () => ({
     createJornadaController: jest.fn(),
-    getAllJornadasController: jest.fn(), 
+    getAllJornadasController: jest.fn(),
+    exportCsvController: jest.fn(),
     getCurrentJornadaController: jest.fn(),
     startTurnController: jest.fn(),
     finishTurnController: jest.fn(),
@@ -50,6 +51,37 @@ describe("JornadaHandler", () => {
     });
 
     expect(jornadaController.getCurrentJornadaController).toHaveBeenCalled();
+    expect(result.statusCode).toBe(200);
+  });
+
+  test("delegates GET /jornadas to getAllJornadasController", async () => {
+    jornadaController.getAllJornadasController.mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ success: true }),
+    });
+
+    const result = await handler({
+      httpMethod: "GET",
+      resource: "/jornadas",
+    });
+
+    expect(jornadaController.getAllJornadasController).toHaveBeenCalled();
+    expect(result.statusCode).toBe(200);
+  });
+
+  test("delegates GET /jornadas/exportar to exportCsvController", async () => {
+    jornadaController.exportCsvController.mockResolvedValue({
+      statusCode: 200,
+      headers: { "Content-Type": "text/csv" },
+      body: "ID Jornada,...",
+    });
+
+    const result = await handler({
+      httpMethod: "GET",
+      resource: "/jornadas/exportar",
+    });
+
+    expect(jornadaController.exportCsvController).toHaveBeenCalled();
     expect(result.statusCode).toBe(200);
   });
 

--- a/__tests__/unit/jornada-services-test/jornadaRepository.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaRepository.test.mjs
@@ -110,4 +110,90 @@ describe("JornadaRepository", () => {
     expect(query).toContain("duracion_total_segundos");
     expect(values).toEqual(["jor-1", "ok"]);
   });
+
+  test("findAll sin filtros retorna todas las jornadas con duracion_total y tiene_observaciones", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ id: "jor-1", duracion_total: "08:00", tiene_observaciones: false }],
+    });
+
+    const result = await repository.findAll();
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("duracion_total");
+    expect(query).toContain("tiene_observaciones");
+    expect(query).toContain("ORDER BY j.created_at DESC");
+    expect(params).toEqual([]);
+    expect(result[0].id).toBe("jor-1");
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  test("findAll filtra por texto de búsqueda general con ILIKE", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findAll({ q: "ABC" });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("ILIKE");
+    expect(query).toContain("un.placa");
+    expect(params).toEqual(["%ABC%"]);
+  });
+
+  test("findAll filtra por conductor_id", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findAll({ conductor_id: "cond-1" });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("j.conductor_id = $");
+    expect(params).toContain("cond-1");
+  });
+
+  test("findAll filtra por rango de fechas", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findAll({ fecha_desde: "2026-01-01", fecha_hasta: "2026-04-30" });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("j.fecha_jornada >=");
+    expect(query).toContain("j.fecha_jornada <=");
+    expect(params).toContain("2026-01-01");
+    expect(params).toContain("2026-04-30");
+  });
+
+  test("findAll combina múltiples filtros con AND", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findAll({ conductor_id: "cond-1", fecha_desde: "2026-04-01" });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("WHERE");
+    expect(params).toHaveLength(2);
+  });
+
+  test("exportAll retorna columnas para CSV con placa separada", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ id: "jor-1", placa: "ABC-123", duracion_total: "08:00" }],
+    });
+
+    const result = await repository.exportAll({});
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("un.placa");
+    expect(query).toContain("duracion_total");
+    expect(query).toContain("TO_CHAR(j.hora_inicio");
+    expect(query).toContain("TO_CHAR(j.hora_fin");
+    expect(params).toEqual([]);
+    expect(result[0].placa).toBe("ABC-123");
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  test("exportAll aplica los mismos filtros que findAll", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.exportAll({ q: "XYZ", conductor_id: "cond-2" });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("ILIKE");
+    expect(params).toEqual(["%XYZ%", "cond-2"]);
+  });
 });

--- a/__tests__/unit/jornada-services-test/jornadaService.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaService.test.mjs
@@ -11,6 +11,8 @@ jest.unstable_mockModule(
       checkConductorActivo: jest.fn(),
       startTurn: jest.fn(),
       finishTurn: jest.fn(),
+      findAll: jest.fn(),
+      exportAll: jest.fn(),
     })),
   }),
 );
@@ -173,5 +175,96 @@ describe("JornadaService", () => {
       message: "La jornada solo puede finalizarse cuando está EN_PROCESO.",
       code: "JORNADA_NOT_IN_PROGRESS",
     });
+  });
+
+  test("obtiene todas las jornadas sin filtros y delega al repository", async () => {
+    jornadaService.repository.findAll.mockResolvedValue([
+      { id: "jor-1", duracion_total: "08:00", tiene_observaciones: false },
+    ]);
+
+    const result = await jornadaService.getAllJornadas();
+
+    expect(jornadaService.repository.findAll).toHaveBeenCalledWith({});
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("jor-1");
+  });
+
+  test("pasa los filtros al repository en getAllJornadas", async () => {
+    jornadaService.repository.findAll.mockResolvedValue([]);
+
+    const filtros = { q: "ABC-123", conductor_id: "cond-1", fecha_desde: "2026-01-01", fecha_hasta: "2026-04-30" };
+    await jornadaService.getAllJornadas(filtros);
+
+    expect(jornadaService.repository.findAll).toHaveBeenCalledWith(filtros);
+  });
+
+  test("genera CSV con los datos de exportación", async () => {
+    jornadaService.repository.exportAll.mockResolvedValue([
+      {
+        id: "jor-1",
+        fecha: "2026-04-08",
+        conductor: "Juan Perez",
+        placa: "ABC-123",
+        contrato: "CON-001",
+        hora_inicio: "2026-04-08 08:00:00",
+        hora_fin: "2026-04-08 16:00:00",
+        duracion_total: "08:00",
+        km_recorridos: 150,
+        estado: "COMPLETADA",
+        observaciones: null,
+      },
+    ]);
+
+    const csv = await jornadaService.generateCsv({});
+
+    expect(typeof csv).toBe("string");
+    expect(csv).toContain("ID Jornada,Fecha,Conductor,Placa del Camion");
+    expect(csv).toContain("jor-1");
+    expect(csv).toContain("ABC-123");
+    expect(csv).toContain("08:00");
+    expect(jornadaService.repository.exportAll).toHaveBeenCalledWith({});
+  });
+
+  test("genera CSV vacío cuando no hay jornadas", async () => {
+    jornadaService.repository.exportAll.mockResolvedValue([]);
+
+    const csv = await jornadaService.generateCsv({});
+
+    expect(csv).toBe(
+      "ID Jornada,Fecha,Conductor,Placa del Camion,Contrato,Hora Inicio,Hora Fin,Duracion Total,KM Recorridos,Estado,Observaciones",
+    );
+  });
+
+  test("escapa correctamente valores con comas en el CSV", async () => {
+    jornadaService.repository.exportAll.mockResolvedValue([
+      {
+        id: "jor-1",
+        fecha: "2026-04-08",
+        conductor: "Perez, Juan",
+        placa: "ABC-123",
+        contrato: "CON-001",
+        hora_inicio: null,
+        hora_fin: null,
+        duracion_total: "Sin iniciar",
+        km_recorridos: 0,
+        estado: "REGISTRADA",
+        observaciones: 'Nota con "comillas"',
+      },
+    ]);
+
+    const csv = await jornadaService.generateCsv({});
+    const lines = csv.split('\n');
+
+    expect(lines[1]).toContain('"Perez, Juan"');
+    expect(lines[1]).toContain('"Nota con ""comillas"""');
+  });
+
+  test("pasa los filtros al repository en generateCsv", async () => {
+    jornadaService.repository.exportAll.mockResolvedValue([]);
+
+    const filtros = { conductor_id: "cond-1", fecha_desde: "2026-04-01" };
+    await jornadaService.generateCsv(filtros);
+
+    expect(jornadaService.repository.exportAll).toHaveBeenCalledWith(filtros);
   });
 });

--- a/src/functions/jornada-services/jornadaController.mjs
+++ b/src/functions/jornada-services/jornadaController.mjs
@@ -80,13 +80,48 @@ export const finishTurnController = async (event) => {
     return resolveErrorResponse(error);
   }
 };
-export const getAllJornadasController = async (_event) => {
+
+export const getAllJornadasController = async (event) => {
   try {
     const jornadaService = new JornadaService();
-    const data = await jornadaService.getAllJornadas();
+    const { q, conductor_id, fecha_desde, fecha_hasta } =
+      event.queryStringParameters || {};
+    const data = await jornadaService.getAllJornadas({
+      q,
+      conductor_id,
+      fecha_desde,
+      fecha_hasta,
+    });
     return successResponse(data, "Jornadas obtenidas exitosamente.");
   } catch (error) {
     console.error("Error en getAllJornadasController:", error);
+    return resolveErrorResponse(error);
+  }
+};
+
+export const exportCsvController = async (event) => {
+  try {
+    const jornadaService = new JornadaService();
+    const { q, conductor_id, fecha_desde, fecha_hasta } =
+      event.queryStringParameters || {};
+    const csv = await jornadaService.generateCsv({
+      q,
+      conductor_id,
+      fecha_desde,
+      fecha_hasta,
+    });
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'text/csv',
+        'Content-Disposition': 'attachment; filename="jornadas.csv"',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: csv,
+    };
+  } catch (error) {
+    console.error("Error en exportCsvController:", error);
     return resolveErrorResponse(error);
   }
 };

--- a/src/functions/jornada-services/jornadaHandler.mjs
+++ b/src/functions/jornada-services/jornadaHandler.mjs
@@ -1,6 +1,7 @@
 import {
   createJornadaController,
   getAllJornadasController,
+  exportCsvController,
   getCurrentJornadaController,
   startTurnController,
   finishTurnController,
@@ -9,6 +10,7 @@ import { errorResponse } from "../../shared/utils/response/response.mjs";
 
 const ROUTES = {
   "POST /jornadas": createJornadaController,
+  "GET /jornadas/exportar": exportCsvController,
   "GET /jornadas/actual/{conductorId}": getCurrentJornadaController,
   "GET /jornadas": getAllJornadasController,
   "POST /jornadas/iniciar": startTurnController,
@@ -29,4 +31,3 @@ export const handler = async (event) => {
 
   return routeHandler(event);
 };
-

--- a/src/functions/jornada-services/jornadaRepository.mjs
+++ b/src/functions/jornada-services/jornadaRepository.mjs
@@ -20,6 +20,45 @@ const BASE_SELECT = `
   FROM jornadas
 `;
 
+const DURATION_SQL = `
+  CASE
+    WHEN j.hora_fin IS NOT NULL
+      THEN LPAD((EXTRACT(EPOCH FROM (j.hora_fin - j.hora_inicio))::BIGINT / 3600)::TEXT, 2, '0') || ':' ||
+           LPAD(((EXTRACT(EPOCH FROM (j.hora_fin - j.hora_inicio))::BIGINT % 3600) / 60)::TEXT, 2, '0')
+    WHEN j.estado = 'EN_PROCESO' THEN 'En curso'
+    WHEN j.estado = 'REGISTRADA' THEN 'Sin iniciar'
+    ELSE '-'
+  END
+`;
+
+function buildFilters({ q, conductor_id, fecha_desde, fecha_hasta } = {}) {
+  const conditions = [];
+  const params = [];
+
+  if (q) {
+    params.push(`%${q}%`);
+    const idx = params.length;
+    conditions.push(`(un.placa ILIKE $${idx} OR u.nombres || ' ' || u.apellidos ILIKE $${idx})`);
+  }
+  if (conductor_id) {
+    params.push(conductor_id);
+    conditions.push(`j.conductor_id = $${params.length}`);
+  }
+  if (fecha_desde) {
+    params.push(fecha_desde);
+    conditions.push(`j.fecha_jornada >= $${params.length}`);
+  }
+  if (fecha_hasta) {
+    params.push(fecha_hasta);
+    conditions.push(`j.fecha_jornada <= $${params.length}`);
+  }
+
+  return {
+    whereClause: conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '',
+    params,
+  };
+}
+
 export class JornadaRepository {
   async create(jornadaData) {
     const client = await getClient();
@@ -214,35 +253,70 @@ export class JornadaRepository {
       client.release();
     }
   }
-  async findAll() {
-  const client = await getClient();
-  try {
-    const result = await client.query(`
-      SELECT
-        j.id,
-        j.fecha_jornada AS fecha,
-        u.nombres || ' ' || u.apellidos AS conductor,
-        un.placa || ' - ' || un.marca || ' ' || un.modelo AS camion,
-        c.codigo AS contrato,
-        CASE
-          WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
-            THEN TO_CHAR(j.hora_inicio, 'HH:MI AM') || ' - ' || TO_CHAR(j.hora_fin, 'HH:MI AM')
-          WHEN j.hora_inicio IS NOT NULL
-            THEN TO_CHAR(j.hora_inicio, 'HH:MI AM') || ' - En curso'
-          ELSE 'Sin iniciar'
-        END AS horario,
-        j.km_recorridos AS km,
-        j.estado,
-        j.observaciones
-      FROM jornadas j
-      JOIN usuarios u ON u.id = j.conductor_id
-      JOIN unidades un ON un.id = j.unidad_id
-      JOIN contratos c ON c.id = j.contrato_id
-      ORDER BY j.created_at DESC;
-    `);
-    return result.rows;
-  } finally {
-    client.release();
+
+  async findAll(filtros = {}) {
+    const client = await getClient();
+    try {
+      const { whereClause, params } = buildFilters(filtros);
+      const result = await client.query(`
+        SELECT
+          j.id,
+          j.fecha_jornada AS fecha,
+          u.nombres || ' ' || u.apellidos AS conductor,
+          un.placa || ' - ' || un.marca || ' ' || un.modelo AS camion,
+          c.codigo AS contrato,
+          CASE
+            WHEN j.hora_inicio IS NOT NULL AND j.hora_fin IS NOT NULL
+              THEN TO_CHAR(j.hora_inicio, 'HH:MI AM') || ' - ' || TO_CHAR(j.hora_fin, 'HH:MI AM')
+            WHEN j.hora_inicio IS NOT NULL
+              THEN TO_CHAR(j.hora_inicio, 'HH:MI AM') || ' - En curso'
+            ELSE 'Sin iniciar'
+          END AS horario,
+          j.km_recorridos AS km,
+          j.estado,
+          j.observaciones,
+          ${DURATION_SQL} AS duracion_total,
+          (j.observaciones IS NOT NULL AND j.observaciones <> '') AS tiene_observaciones
+        FROM jornadas j
+        JOIN usuarios u ON u.id = j.conductor_id
+        JOIN unidades un ON un.id = j.unidad_id
+        JOIN contratos c ON c.id = j.contrato_id
+        ${whereClause}
+        ORDER BY j.created_at DESC;
+      `, params);
+      return result.rows;
+    } finally {
+      client.release();
+    }
   }
-}
+
+  async exportAll(filtros = {}) {
+    const client = await getClient();
+    try {
+      const { whereClause, params } = buildFilters(filtros);
+      const result = await client.query(`
+        SELECT
+          j.id,
+          TO_CHAR(j.fecha_jornada, 'YYYY-MM-DD') AS fecha,
+          u.nombres || ' ' || u.apellidos AS conductor,
+          un.placa,
+          c.codigo AS contrato,
+          TO_CHAR(j.hora_inicio, 'YYYY-MM-DD HH24:MI:SS') AS hora_inicio,
+          TO_CHAR(j.hora_fin, 'YYYY-MM-DD HH24:MI:SS') AS hora_fin,
+          ${DURATION_SQL} AS duracion_total,
+          j.km_recorridos,
+          j.estado,
+          j.observaciones
+        FROM jornadas j
+        JOIN usuarios u ON u.id = j.conductor_id
+        JOIN unidades un ON un.id = j.unidad_id
+        JOIN contratos c ON c.id = j.contrato_id
+        ${whereClause}
+        ORDER BY j.created_at DESC;
+      `, params);
+      return result.rows;
+    } finally {
+      client.release();
+    }
+  }
 }

--- a/src/functions/jornada-services/jornadaService.mjs
+++ b/src/functions/jornada-services/jornadaService.mjs
@@ -11,6 +11,15 @@ function createJornadaError(message, statusCode = 400, code = "JORNADA_ERROR") {
   return error;
 }
 
+const escapeCsv = (value) => {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+};
+
 export class JornadaService {
   constructor() {
     this.repository = new JornadaRepository();
@@ -115,7 +124,30 @@ export class JornadaService {
     const updated = await this.repository.finishTurn(jornadaId, observaciones);
     return Jornada.fromDatabase(updated);
   }
-  async getAllJornadas() {
-  return this.repository.findAll();
-}
+
+  async getAllJornadas(filtros = {}) {
+    return this.repository.findAll(filtros);
+  }
+
+  async generateCsv(filtros = {}) {
+    const rows = await this.repository.exportAll(filtros);
+
+    const header = 'ID Jornada,Fecha,Conductor,Placa del Camion,Contrato,Hora Inicio,Hora Fin,Duracion Total,KM Recorridos,Estado,Observaciones';
+
+    const csvRows = rows.map((row) => [
+      escapeCsv(row.id),
+      escapeCsv(row.fecha),
+      escapeCsv(row.conductor),
+      escapeCsv(row.placa),
+      escapeCsv(row.contrato),
+      escapeCsv(row.hora_inicio),
+      escapeCsv(row.hora_fin),
+      escapeCsv(row.duracion_total),
+      escapeCsv(row.km_recorridos),
+      escapeCsv(row.estado),
+      escapeCsv(row.observaciones),
+    ].join(','));
+
+    return [header, ...csvRows].join('\n');
+  }
 }


### PR DESCRIPTION
## HU05 - Seguimiento de Jornadas

Closes #172
Closes #173
Closes #174

---

## ¿Qué se implementó?

### Issue #172 — GET /jornadas con filtros
Endpoint para listar jornadas con filtros opcionales por query parameters.

**Método:** GET  
**URL:** /jornadas  
**Headers:** Content-Type: application/json  
**Query params (todos opcionales):**
- q: búsqueda general por placa o nombre de conductor
- conductor_id: UUID del conductor
- fecha_desde: YYYY-MM-DD
- fecha_hasta: YYYY-MM-DD

**Respuesta 200:**
```json
{
  "success": true,
  "message": "Jornadas obtenidas exitosamente.",
  "data": [
    {
      "id": "uuid",
      "fecha": "2026-04-19",
      "conductor": "Carlos Gomez",
      "camion": "ABC-123 - Mercedes Benz Actros",
      "contrato": "CONT-001",
      "horario": "10:51 AM - 05:51 PM",
      "km": 120.50,
      "estado": "COMPLETADA",
      "duracion_total": "07:00",
      "tiene_observaciones": true,
      "observaciones": "Texto de observaciones"
    }
  ]
}
```

---

### Issue #173 — Cálculo de duración total
Campo `duracion_total` calculado directamente en SQL:
- Si tiene hora_fin: formato HH:MM
- Si estado = EN_PROCESO: "En curso"
- Si estado = REGISTRADA o PENDIENTE: "Sin iniciar"
- Otros: "-"

Campo `tiene_observaciones`: boolean, true si hay texto en observaciones.

---

### Issue #174 — GET /jornadas/exportar
Endpoint para exportar jornadas filtradas a CSV descargable.

**Método:** GET  
**URL:** /jornadas/exportar  
**Query params:** mismos que GET /jornadas  
**Respuesta:** archivo jornadas.csv  
**Headers de respuesta:**
- Content-Type: text/csv
- Content-Disposition: attachment; filename="jornadas.csv"

**Columnas del CSV:** ID Jornada, Fecha, Conductor, Placa del Camion, Contrato, Hora Inicio, Hora Fin, Duracion Total, KM Recorridos, Estado, Observaciones

---

## Archivos modificados
- src/functions/jornada-services/jornadaRepository.mjs
- src/functions/jornada-services/jornadaService.mjs
- src/functions/jornada-services/jornadaController.mjs
- src/functions/jornada-services/jornadaHandler.mjs
- __tests__/unit/jornada-services-test/jornadaController.test.mjs
- __tests__/unit/jornada-services-test/jornadaService.test.mjs
- __tests__/unit/jornada-services-test/jornadaHandler.test.mjs
- __tests__/unit/jornada-services-test/jornadaRepository.test.mjs

## Tests
78 tests passing ✅