### PR TITLE
Ajuste de autenticación, seeds y documentación backend Sprint 2

### DIFF
--- a/__tests__/helpers/pgMemDb.mjs
+++ b/__tests__/helpers/pgMemDb.mjs
@@ -82,9 +82,10 @@ CREATE TABLE camiones (
 const pgMemSeedSQL = `
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', '7438d4b8-0021-7065-dda7-7bbdfa75c929', 'admin@nanutech.com', 'Jimena', 'Rodriguez', 'ADMIN', '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer1@nanutech.com', 'Carlos', 'Mendoza', 'CHOFER', '999222333', '70000002'),
-('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002', 'chofer2@nanutech.com', 'Luis', 'Ramirez', 'CHOFER', '999333444', '70000003');
+('11111111-1111-1111-1111-111111111111', '74f8c4f8-a041-70ca-4e30-e78b87d1cfdb', 'admin@nanutech.com', 'Jimena', 'Rodriguez', 'ADMIN', '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer@nanutech.com', 'Carlos', 'Mendoza', 'CHOFER', '999222333', '70000002'),
+('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002', 'chofer2@nanutech.com', 'Luis', 'Ramirez', 'CHOFER', '999333444', '70000003'),
+('55555555-5555-5555-5555-555555555555', '744844e8-d051-70fb-a746-c22ccc07352a', 'gerente@nanutech.com', 'Laura', 'Vasquez', 'GERENTE', '999777888', '70000005');
 
 INSERT INTO unidades (id, placa, marca, modelo, anio, capacidad_ton, estado)
 VALUES

--- a/__tests__/unit/auth-services-test/authHandler.test.mjs
+++ b/__tests__/unit/auth-services-test/authHandler.test.mjs
@@ -49,6 +49,25 @@ describe("AuthHandler", () => {
     expect(body.data.session.accessToken).toBeTruthy();
   });
 
+  it("responde login local del gerente con ruta gerencial", async () => {
+    const response = await authHandler({
+      httpMethod: "POST",
+      resource: "/auth/login",
+      body: JSON.stringify({
+        email: "gerente@test.com",
+        password: "123456",
+      }),
+      headers: {},
+    });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.user.role).toBe("gerente");
+    expect(body.data.role).toBe("gerente");
+    expect(body.data.nextRoute).toBe("/dashboard/gerencial");
+  });
+
   it("valida token en /auth/me y devuelve el perfil usable por el cliente", async () => {
     const loginResponse = await authHandler({
       httpMethod: "POST",

--- a/__tests__/unit/auth-services-test/authModel.test.mjs
+++ b/__tests__/unit/auth-services-test/authModel.test.mjs
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "@jest/globals";
+import { UserModel } from "../../../src/functions/auth-services/authModel.mjs";
+
+describe("AuthModel", () => {
+  it("expone la estructura base de usuario local", () => {
+    expect(UserModel).toEqual({
+      email: "",
+      password: "",
+      role: "",
+      attempts: 0,
+      locked: false,
+    });
+  });
+});

--- a/__tests__/unit/auth-services-test/authService.test.mjs
+++ b/__tests__/unit/auth-services-test/authService.test.mjs
@@ -91,6 +91,22 @@ describe("AuthService", () => {
     expect(result.session.idleTimeoutSeconds).toBe(7200);
   });
 
+  it("permite login local del gerente y redirige al dashboard gerencial", async () => {
+    const result = await authService.handleLoginAttempt(
+      "gerente@test.com",
+      "123456",
+    );
+
+    expect(result.user).toEqual({
+      email: "gerente@test.com",
+      role: "gerente",
+    });
+    expect(result.role).toBe("gerente");
+    expect(result.nextRoute).toBe("/dashboard/gerencial");
+    expect(result.session.provider).toBe("local");
+    expect(result.session.accessToken).toBeTruthy();
+  });
+
   it("mantiene la logica de bloqueo tras 5 intentos fallidos", async () => {
     for (let attempt = 1; attempt <= 4; attempt += 1) {
       await expect(
@@ -125,6 +141,25 @@ describe("AuthService", () => {
     });
     expect(session.role).toBe("chofer");
     expect(session.nextRoute).toBe("/dashboard/chofer");
+    expect(session.session.isAuthenticated).toBe(true);
+  });
+
+  it("expone la sesion actual del gerente local con su ruta gerencial", async () => {
+    const login = await authService.handleLoginAttempt(
+      "gerente@test.com",
+      "123456",
+    );
+
+    const session = await authService.getCurrentSession(
+      `Bearer ${login.session.accessToken}`,
+    );
+
+    expect(session.user).toEqual({
+      email: "gerente@test.com",
+      role: "gerente",
+    });
+    expect(session.role).toBe("gerente");
+    expect(session.nextRoute).toBe("/dashboard/gerencial");
     expect(session.session.isAuthenticated).toBe(true);
   });
 
@@ -263,6 +298,66 @@ describe("AuthService", () => {
     });
     expect(result.role).toBe("admin");
     expect(result.nextRoute).toBe("/dashboard/admin");
+    expect(result.session.provider).toBe("cognito");
+    expect(mockDbQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("resuelve login Cognito del gerente usando el sub real de AWS", async () => {
+    process.env.AUTH_PROVIDER = "cognito";
+    process.env.COGNITO_USER_POOL_ID = "pool-id";
+    process.env.COGNITO_CLIENT_ID = "client-id";
+    process.env.AWS_REGION = "us-east-1";
+
+    const gerenteSub = "744844e8-d051-70fb-a746-c22ccc07352a";
+    const gerenteDbUser = buildDbUser({
+      id: "55555555-5555-5555-5555-555555555555",
+      cognito_sub: gerenteSub,
+      correo: "gerente@nanutech.com",
+      nombres: "Laura",
+      apellidos: "Vasquez",
+      rol: "GERENTE",
+    });
+    const idToken = createJwtLikeToken({
+      sub: gerenteSub,
+      email: "gerente@nanutech.com",
+      "custom:role": "GERENTE",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const accessToken = createJwtLikeToken({
+      sub: gerenteSub,
+      username: "gerente@nanutech.com",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    cognitoClientMock.on(InitiateAuthCommand).resolves({
+      AuthenticationResult: {
+        AccessToken: accessToken,
+        IdToken: idToken,
+        ExpiresIn: 3600,
+      },
+    });
+
+    mockDbQuery
+      .mockResolvedValueOnce({ rows: [gerenteDbUser] })
+      .mockResolvedValueOnce({
+        rows: [{ ...gerenteDbUser, ultimo_acceso: "2026-04-05T10:00:00.000Z" }],
+      });
+
+    const result = await authService.handleLoginAttempt(
+      "gerente@nanutech.com",
+      "Admin123!",
+    );
+
+    expect(result.user).toEqual({
+      id: "55555555-5555-5555-5555-555555555555",
+      email: "gerente@nanutech.com",
+      nombres: "Laura",
+      apellidos: "Vasquez",
+      role: "gerente",
+      estado: "ACTIVO",
+    });
+    expect(result.role).toBe("gerente");
+    expect(result.nextRoute).toBe("/dashboard/gerencial");
     expect(result.session.provider).toBe("cognito");
     expect(mockDbQuery).toHaveBeenCalledTimes(2);
   });

--- a/__tests__/unit/conductor-services/conductorHandler.test.mjs
+++ b/__tests__/unit/conductor-services/conductorHandler.test.mjs
@@ -1,0 +1,58 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let handler;
+let getAllConductoresController;
+
+jest.unstable_mockModule(
+  "../../../src/functions/conductor-services/conductorController.mjs",
+  () => ({
+    getAllConductoresController: jest.fn(),
+  })
+);
+
+beforeAll(async () => {
+  ({ getAllConductoresController } = await import(
+    "../../../src/functions/conductor-services/conductorController.mjs"
+  ));
+  ({ handler } = await import("../../../src/functions/conductor-services/conductorHandler.mjs"));
+});
+
+describe("conductorHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("enruta GET /conductores al controller", async () => {
+    const expected = { statusCode: 200, body: JSON.stringify({ data: [] }) };
+    getAllConductoresController.mockResolvedValue(expected);
+
+    const result = await handler({ httpMethod: "GET", resource: "/conductores" });
+
+    expect(result).toBe(expected);
+    expect(getAllConductoresController).toHaveBeenCalledWith({
+      httpMethod: "GET",
+      resource: "/conductores",
+    });
+  });
+
+  it("retorna 404 si la ruta no existe", async () => {
+    const result = await handler({ httpMethod: "POST", resource: "/conductores" });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(404);
+    expect(body.success).toBe(false);
+    expect(body.message).toContain("Ruta POST /conductores no encontrada");
+  });
+
+  it("retorna 500 si el controller lanza error", async () => {
+    getAllConductoresController.mockRejectedValue(new Error("DB down"));
+
+    const result = await handler({ httpMethod: "GET", resource: "/conductores" });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.message).toBe("DB down");
+  });
+});

--- a/__tests__/unit/conductor-services/conductorModel.test.mjs
+++ b/__tests__/unit/conductor-services/conductorModel.test.mjs
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "@jest/globals";
+import { Conductor } from "../../../src/functions/conductor-services/conductorModel.mjs";
+
+describe("ConductorModel", () => {
+  const row = {
+    id: "usr-1",
+    cognito_sub: "sub-1",
+    correo: "chofer@nanutech.com",
+    nombres: "Carlos",
+    apellidos: "Gomez",
+    rol: "CHOFER",
+    telefono: "999888777",
+    dni: "12345678",
+    activo: true,
+    estado: "ACTIVO",
+  };
+
+  it("crea una instancia desde una fila de base de datos", () => {
+    const conductor = Conductor.fromDatabase(row);
+
+    expect(conductor).toBeInstanceOf(Conductor);
+    expect(conductor).toMatchObject(row);
+  });
+
+  it("mapea listas desde filas de base de datos", () => {
+    const result = Conductor.fromDatabaseList([row]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(Conductor);
+    expect(result[0].correo).toBe("chofer@nanutech.com");
+  });
+});

--- a/__tests__/unit/conductor-services/conductorRepository.test.mjs
+++ b/__tests__/unit/conductor-services/conductorRepository.test.mjs
@@ -1,0 +1,45 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+const dbMock = {
+  query: jest.fn(),
+};
+
+let ConductorRepository;
+
+jest.unstable_mockModule("../../../src/shared/config/database.mjs", () => ({
+  default: dbMock,
+}));
+
+beforeAll(async () => {
+  ({ ConductorRepository } = await import(
+    "../../../src/functions/conductor-services/conductorRepository.mjs"
+  ));
+});
+
+describe("ConductorRepository", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("consulta usuarios chofer activos ordenados por apellidos y nombres", async () => {
+    const rows = [{ id: "usr-1", rol: "CHOFER", activo: true, estado: "ACTIVO" }];
+    dbMock.query.mockResolvedValue({ rows });
+
+    const repository = new ConductorRepository();
+    const result = await repository.getAllActive();
+
+    expect(result).toEqual(rows);
+    expect(dbMock.query).toHaveBeenCalledTimes(1);
+    expect(dbMock.query.mock.calls[0][0]).toContain("WHERE rol = 'CHOFER'");
+    expect(dbMock.query.mock.calls[0][0]).toContain("estado = 'ACTIVO'");
+    expect(dbMock.query.mock.calls[0][0]).toContain("ORDER BY apellidos, nombres");
+  });
+
+  it("propaga errores de base de datos", async () => {
+    dbMock.query.mockRejectedValue(new Error("DB error"));
+
+    const repository = new ConductorRepository();
+
+    await expect(repository.getAllActive()).rejects.toThrow("DB error");
+  });
+});

--- a/__tests__/unit/contrato-services/contratoHandler.test.mjs
+++ b/__tests__/unit/contrato-services/contratoHandler.test.mjs
@@ -1,0 +1,106 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let handler;
+let controllers;
+
+jest.unstable_mockModule("../../../src/functions/contrato-services/contratoController.mjs", () => ({
+  getAllVigentesController: jest.fn(),
+  createContratoController: jest.fn(),
+  getIndicadoresController: jest.fn(),
+  getAllContratosController: jest.fn(),
+  getContratoByIdController: jest.fn(),
+  updateContratoController: jest.fn(),
+  assignUnidadesController: jest.fn(),
+}));
+
+beforeAll(async () => {
+  controllers = await import("../../../src/functions/contrato-services/contratoController.mjs");
+  ({ handler } = await import("../../../src/functions/contrato-services/contratoHandler.mjs"));
+});
+
+describe("contratoHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const expectRoute = async (event, controllerName) => {
+    const expected = { statusCode: 200, body: JSON.stringify({ ok: true }) };
+    controllers[controllerName].mockResolvedValue(expected);
+
+    const result = await handler(event);
+
+    expect(result).toBe(expected);
+    expect(controllers[controllerName]).toHaveBeenCalledWith(event);
+  };
+
+  it("enruta GET /contratos/indicadores", async () => {
+    await expectRoute(
+      { httpMethod: "GET", resource: "/contratos/indicadores" },
+      "getIndicadoresController"
+    );
+  });
+
+  it("enruta GET /contratos/vigentes", async () => {
+    await expectRoute(
+      { httpMethod: "GET", resource: "/contratos/vigentes" },
+      "getAllVigentesController"
+    );
+  });
+
+  it("enruta POST /contratos", async () => {
+    await expectRoute(
+      { httpMethod: "POST", resource: "/contratos" },
+      "createContratoController"
+    );
+  });
+
+  it("enruta GET /contratos/{id}", async () => {
+    await expectRoute(
+      { httpMethod: "GET", resource: "/contratos/{id}", pathParameters: { id: "con-1" } },
+      "getContratoByIdController"
+    );
+  });
+
+  it("enruta GET /contratos", async () => {
+    await expectRoute(
+      { httpMethod: "GET", resource: "/contratos" },
+      "getAllContratosController"
+    );
+  });
+
+  it("enruta PUT /contratos/{id}", async () => {
+    await expectRoute(
+      { httpMethod: "PUT", resource: "/contratos/{id}", pathParameters: { id: "con-1" } },
+      "updateContratoController"
+    );
+  });
+
+  it("enruta PUT /contratos/{id}/unidades", async () => {
+    await expectRoute(
+      {
+        httpMethod: "PUT",
+        resource: "/contratos/{id}/unidades",
+        pathParameters: { id: "con-1" },
+      },
+      "assignUnidadesController"
+    );
+  });
+
+  it("retorna 404 cuando la ruta no existe", async () => {
+    const result = await handler({ httpMethod: "DELETE", resource: "/contratos/{id}" });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(404);
+    expect(body.message).toBe("Ruta DELETE /contratos/{id} no encontrada");
+  });
+
+  it("retorna 500 si el controller lanza error inesperado", async () => {
+    controllers.getAllContratosController.mockRejectedValue(new Error("Fallo inesperado"));
+
+    const result = await handler({ httpMethod: "GET", resource: "/contratos" });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(500);
+    expect(body.message).toBe("Fallo inesperado");
+  });
+});

--- a/__tests__/unit/contrato-services/contratoModel.test.mjs
+++ b/__tests__/unit/contrato-services/contratoModel.test.mjs
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "@jest/globals";
+import { Contrato } from "../../../src/functions/contrato-services/contratoModel.mjs";
+
+describe("ContratoModel", () => {
+  const row = {
+    id: "con-1",
+    codigo: "CONT-001",
+    cliente: "Empresa ABC",
+    descripcion: "Servicio mensual",
+    fecha_inicio: "2026-05-01",
+    fecha_fin: "2026-08-01",
+    tarifa: "1200.50",
+    moneda: "PEN",
+    estado: "VIGENTE",
+    activo: true,
+    ruc: "12345678901",
+    tipo_servicio: "POR_KM",
+    origen: "Arequipa",
+    destino: "Matarani",
+    distancia_estimada_km: "180.00",
+    tarifa_por_km: "5.00",
+    tarifa_por_hora: "30.00",
+    tarifa_espera: "20.00",
+    total_referencial: "900.00",
+  };
+
+  it("crea una instancia completa desde una fila de base de datos", () => {
+    const contrato = Contrato.fromDatabase(row);
+
+    expect(contrato).toBeInstanceOf(Contrato);
+    expect(contrato).toMatchObject({
+      id: "con-1",
+      codigo: "CONT-001",
+      cliente: "Empresa ABC",
+      descripcion: "Servicio mensual",
+      fecha_inicio: "2026-05-01",
+      fecha_fin: "2026-08-01",
+      tarifa: "1200.50",
+      moneda: "PEN",
+      estado: "VIGENTE",
+      activo: true,
+      ruc: "12345678901",
+      tipo_servicio: "POR_KM",
+      ruta: {
+        origen: "Arequipa",
+        destino: "Matarani",
+        distancia_estimada_km: "180.00",
+      },
+      tarifas: {
+        tarifa_por_km: "5.00",
+        tarifa_por_hora: "30.00",
+        tarifa_espera: "20.00",
+        total_referencial: "900.00",
+      },
+    });
+  });
+
+  it("usa null en ruta y tarifas cuando la fila no trae datos opcionales", () => {
+    const contrato = Contrato.fromDatabase({
+      id: "con-2",
+      codigo: "CONT-002",
+      cliente: "Empresa XYZ",
+      descripcion: null,
+      fecha_inicio: "2026-05-01",
+      fecha_fin: null,
+      tarifa: "0.00",
+      moneda: "PEN",
+      estado: "VIGENTE",
+      activo: true,
+    });
+
+    expect(contrato.ruc).toBeNull();
+    expect(contrato.tipo_servicio).toBeNull();
+    expect(contrato.ruta).toEqual({
+      origen: null,
+      destino: null,
+      distancia_estimada_km: null,
+    });
+    expect(contrato.tarifas).toEqual({
+      tarifa_por_km: null,
+      tarifa_por_hora: null,
+      tarifa_espera: null,
+      total_referencial: null,
+    });
+  });
+
+  it("mapea listas de contratos desde filas de base de datos", () => {
+    const result = Contrato.fromDatabaseList([row]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(Contrato);
+    expect(result[0].codigo).toBe("CONT-001");
+  });
+});

--- a/__tests__/unit/contrato-services/contratoRepository.test.mjs
+++ b/__tests__/unit/contrato-services/contratoRepository.test.mjs
@@ -1,11 +1,12 @@
 import { jest } from "@jest/globals";
 
 const mockQuery = jest.fn();
+const mockGetClient = jest.fn();
 
 jest.unstable_mockModule("../../../src/shared/config/database.mjs", () => ({
-  default: { query: mockQuery },
+  default: { query: mockQuery, getClient: mockGetClient },
   query: mockQuery,
-  getClient: jest.fn(),
+  getClient: mockGetClient,
 }));
 
 const { ContratoRepository } = await import(
@@ -18,6 +19,7 @@ describe("ContratoRepository", () => {
   beforeEach(() => {
     repository = new ContratoRepository();
     mockQuery.mockReset();
+    mockGetClient.mockReset();
   });
 
   test("getAllVigentes retorna contratos vigentes filtrando por estado y fecha", async () => {
@@ -174,5 +176,174 @@ describe("ContratoRepository", () => {
     const result = await repository.findById("non-existent-id");
 
     expect(result).toBeNull();
+  });
+
+  test("calculateTotalReferencial multiplica distancia por tarifa por km", () => {
+    const result = repository.calculateTotalReferencial({
+      distancia_estimada_km: 180,
+      tarifa_por_km: 5.5,
+    });
+
+    expect(result).toBe(990);
+  });
+
+  test("generateCodigoContrato genera codigo con prefijo CONT", () => {
+    const result = repository.generateCodigoContrato();
+
+    expect(result).toMatch(/^CONT-\d+-\d+$/);
+  });
+
+  test("createContrato registra contrato completo dentro de una transaccion", async () => {
+    const client = {
+      query: jest.fn(),
+      release: jest.fn(),
+    };
+    mockGetClient.mockResolvedValue(client);
+    jest.spyOn(repository, "generateCodigoContrato").mockReturnValue("CONT-TEST");
+
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: "con-1", codigo: "CONT-TEST" }] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ rows: [{ id: "con-1", cliente: "Empresa ABC" }] })
+      .mockResolvedValueOnce({}); // COMMIT
+
+    const result = await repository.createContrato({
+      cliente: " Empresa ABC ",
+      ruc: "12345678901",
+      descripcion: "Contrato mensual",
+      tipo_servicio: "POR_KM",
+      fecha_inicio: "2026-05-01",
+      fecha_fin: "2026-08-01",
+      moneda: "PEN",
+      origen: "Arequipa",
+      destino: "Matarani",
+      distancia_estimada_km: 180,
+      tarifa_por_km: 5,
+      tarifa_por_hora: 0,
+      tarifa_espera: 20,
+    });
+
+    expect(result).toEqual({ id: "con-1", cliente: "Empresa ABC" });
+    expect(client.query).toHaveBeenNthCalledWith(1, "BEGIN");
+    expect(client.query.mock.calls[1][1]).toContain("CONT-TEST");
+    expect(client.query.mock.calls[1][1]).toContain("Empresa ABC");
+    expect(client.query.mock.calls[2][1]).toEqual(["con-1", "Arequipa", "Matarani", "180.00"]);
+    expect(client.query.mock.calls[3][1]).toEqual(["con-1", "5.00", "0.00", "20.00", 900]);
+    expect(client.query).toHaveBeenNthCalledWith(6, "COMMIT");
+    expect(client.release).toHaveBeenCalled();
+  });
+
+  test("createContrato ejecuta rollback y libera cliente si falla", async () => {
+    const client = {
+      query: jest.fn(),
+      release: jest.fn(),
+    };
+    mockGetClient.mockResolvedValue(client);
+
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockRejectedValueOnce(new Error("insert failed"))
+      .mockResolvedValueOnce({}); // ROLLBACK
+
+    await expect(
+      repository.createContrato({
+        cliente: "Empresa ABC",
+        ruc: "12345678901",
+        tipo_servicio: "POR_KM",
+        fecha_inicio: "2026-05-01",
+        origen: "Arequipa",
+        destino: "Matarani",
+        distancia_estimada_km: 180,
+        tarifa_por_km: 5,
+      })
+    ).rejects.toThrow("insert failed");
+
+    expect(client.query).toHaveBeenLastCalledWith("ROLLBACK");
+    expect(client.release).toHaveBeenCalled();
+  });
+
+  test("getFullContratoByIdWithClient retorna el primer contrato encontrado", async () => {
+    const client = {
+      query: jest.fn().mockResolvedValue({ rows: [{ id: "con-1" }] }),
+    };
+
+    const result = await repository.getFullContratoByIdWithClient(client, "con-1");
+
+    expect(result).toEqual({ id: "con-1" });
+    expect(client.query.mock.calls[0][1]).toEqual(["con-1"]);
+  });
+
+  test("getById consulta contrato por id", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: "con-1" }] });
+
+    const result = await repository.getById("con-1");
+
+    expect(result).toEqual({ id: "con-1" });
+    expect(mockQuery.mock.calls[0][1]).toEqual(["con-1"]);
+  });
+
+  test("getTarifasByContrato retorna tarifa o null si falla", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ contrato_id: "con-1", tarifa_base: "100" }] });
+
+    await expect(repository.getTarifasByContrato("con-1")).resolves.toEqual({
+      contrato_id: "con-1",
+      tarifa_base: "100",
+    });
+
+    mockQuery.mockRejectedValueOnce(new Error("tabla no existe"));
+
+    await expect(repository.getTarifasByContrato("con-1")).resolves.toBeNull();
+  });
+
+  test("updateContrato, updateTarifas e historial ejecutan queries con parametros esperados", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.updateContrato("con-1", {
+      fecha_inicio: "2026-05-01",
+      fecha_fin: "2026-08-01",
+      tipo_servicio: "POR_TONELADA",
+      descripcion: "Actualizado",
+      tarifa: 3000,
+    });
+
+    expect(mockQuery.mock.calls[0][1]).toEqual([
+      "2026-05-01",
+      "2026-08-01",
+      "POR_TONELADA",
+      "Actualizado",
+      3000,
+      "con-1",
+    ]);
+
+    await repository.updateTarifas("con-1", { base: 100, hora: 50, tonelada: 80 });
+    expect(mockQuery.mock.calls[1][1]).toEqual([100, 50, 80, "con-1"]);
+
+    await repository.insertHistorial({
+      contrato_id: "con-1",
+      campo: "estado",
+      valor_anterior: "VIGENTE",
+      valor_nuevo: "INACTIVO",
+      ip_address: "127.0.0.1",
+    });
+    expect(mockQuery.mock.calls[2][1]).toEqual([
+      "con-1",
+      "UPDATE",
+      "estado",
+      "VIGENTE",
+      "INACTIVO",
+      "127.0.0.1",
+    ]);
+  });
+
+  test("insertUnidad y deleteUnidades modifican la relacion contrato-unidades", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.insertUnidad("con-1", "uni-1");
+    await repository.deleteUnidades("con-1");
+
+    expect(mockQuery.mock.calls[0][1]).toEqual(["con-1", "uni-1"]);
+    expect(mockQuery.mock.calls[1][1]).toEqual(["con-1"]);
   });
 });

--- a/__tests__/unit/dashboard-gerencial-services/dashboardGerencialModel.test.mjs
+++ b/__tests__/unit/dashboard-gerencial-services/dashboardGerencialModel.test.mjs
@@ -1,0 +1,42 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import { buildDashboardGerencialResponse } from "../../../src/functions/dashboard-gerencial-services/dashboardGerencialModel.mjs";
+
+describe("Dashboard Gerencial - Model", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-05-09T10:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("construye la respuesta consolidada del dashboard gerencial", () => {
+    const resumen = { jornadas: 10 };
+    const graficas = { jornadas_por_dia: [] };
+    const operaciones = { en_progreso: [] };
+    const rendimiento = { top_conductores_km: [] };
+    const historial = [{ id: "j1" }];
+
+    const result = buildDashboardGerencialResponse(
+      resumen,
+      graficas,
+      operaciones,
+      rendimiento,
+      historial
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        ultimo_actualizacion: "2026-05-09T10:00:00.000Z",
+        estado_sistema: "Sistema activo",
+        resumen_general: resumen,
+        graficas,
+        operaciones,
+        rendimiento,
+        historial,
+      },
+    });
+  });
+});

--- a/__tests__/unit/dashboard-gerencial-services/dashboardGerencialRepository.test.mjs
+++ b/__tests__/unit/dashboard-gerencial-services/dashboardGerencialRepository.test.mjs
@@ -1,0 +1,118 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+const query = jest.fn();
+
+let DashboardGerencialRepository;
+
+jest.unstable_mockModule("../../../src/shared/config/database.mjs", () => ({
+  query,
+}));
+
+beforeAll(async () => {
+  ({ DashboardGerencialRepository } = await import(
+    "../../../src/functions/dashboard-gerencial-services/dashboardGerencialRepository.mjs"
+  ));
+});
+
+describe("Dashboard Gerencial - Repository", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("getResumen calcula KPIs gerenciales con filtro hoy", async () => {
+    query
+      .mockResolvedValueOnce({
+        rows: [{ total_jornadas: "10", completadas: "8", total_km: "1500", total_horas: "40.25" }],
+      })
+      .mockResolvedValueOnce({ rows: [{ total: "12" }] })
+      .mockResolvedValueOnce({ rows: [{ total: "7" }] })
+      .mockResolvedValueOnce({ rows: [{ total: "3", ingresos: "2500.50" }] });
+
+    const repository = new DashboardGerencialRepository();
+    const result = await repository.getResumen("hoy");
+
+    expect(result).toEqual({
+      jornadas: 10,
+      jornadas_completadas: 8,
+      horas_acumuladas: "40.25",
+      km_totales: 1500,
+      eficiencia: "80.0%",
+      flota_activa: 12,
+      conductores_activos: 7,
+      contratos_activos: 3,
+      ingresos_estimados: 2500.5,
+    });
+    expect(query.mock.calls[0][0]).toContain("j.fecha_jornada = CURRENT_DATE");
+  });
+
+  it("getResumen retorna eficiencia 0% cuando no hay jornadas", async () => {
+    query
+      .mockResolvedValueOnce({
+        rows: [{ total_jornadas: "0", completadas: "0", total_km: "0", total_horas: "0" }],
+      })
+      .mockResolvedValueOnce({ rows: [{ total: "0" }] })
+      .mockResolvedValueOnce({ rows: [{ total: "0" }] })
+      .mockResolvedValueOnce({ rows: [{ total: "0", ingresos: "0" }] });
+
+    const repository = new DashboardGerencialRepository();
+    const result = await repository.getResumen("todas");
+
+    expect(result.eficiencia).toBe("0%");
+    expect(query.mock.calls[0][0]).not.toContain("INTERVAL");
+  });
+
+  it("getGraficas devuelve agrupaciones usando filtro semana", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ fecha_jornada: "2026-05-01", total: "2", km: "100" }] })
+      .mockResolvedValueOnce({ rows: [{ estado: "COMPLETADA", total: "2" }] })
+      .mockResolvedValueOnce({ rows: [{ estado: "DISPONIBLE", total: "4" }] })
+      .mockResolvedValueOnce({ rows: [{ estado: "ACTIVO", total: "5" }] });
+
+    const repository = new DashboardGerencialRepository();
+    const result = await repository.getGraficas("semana");
+
+    expect(result.jornadas_por_dia).toHaveLength(1);
+    expect(result.sectores_jornadas[0].estado).toBe("COMPLETADA");
+    expect(query.mock.calls[0][0]).toContain("INTERVAL '7 days'");
+  });
+
+  it("getOperaciones agrupa jornadas, camiones en mantenimiento y conductores disponibles", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: "j1", conductor: "Carlos Gomez" }] })
+      .mockResolvedValueOnce({ rows: [{ placa: "ABC-123" }] })
+      .mockResolvedValueOnce({ rows: [{ nombre: "Luis Martinez" }] });
+
+    const repository = new DashboardGerencialRepository();
+    const result = await repository.getOperaciones();
+
+    expect(result).toEqual({
+      en_progreso: [{ id: "j1", conductor: "Carlos Gomez" }],
+      camiones_mantenimiento: [{ placa: "ABC-123" }],
+      conductores_disponibles: [{ nombre: "Luis Martinez" }],
+    });
+  });
+
+  it("getRendimiento devuelve top de conductores y camiones con filtro mes", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ conductor: "Carlos Gomez", km_totales: "500" }] })
+      .mockResolvedValueOnce({ rows: [{ placa: "ABC-123", usos: "4", km_totales: "700" }] });
+
+    const repository = new DashboardGerencialRepository();
+    const result = await repository.getRendimiento("mes");
+
+    expect(result.top_conductores_km[0].conductor).toBe("Carlos Gomez");
+    expect(result.top_camiones_uso[0].placa).toBe("ABC-123");
+    expect(query.mock.calls[0][0]).toContain("INTERVAL '30 days'");
+  });
+
+  it("getHistorial agrega busqueda cuando recibe search", async () => {
+    query.mockResolvedValue({ rows: [{ id: "j1", camion: "ABC-123" }] });
+
+    const repository = new DashboardGerencialRepository();
+    const result = await repository.getHistorial("semana", "ABC");
+
+    expect(result).toEqual([{ id: "j1", camion: "ABC-123" }]);
+    expect(query.mock.calls[0][0]).toContain("ILIKE '%ABC%'");
+    expect(query.mock.calls[0][0]).toContain("ORDER BY j.fecha_jornada DESC");
+  });
+});

--- a/__tests__/unit/dashboard-services/dashboardController.test.mjs
+++ b/__tests__/unit/dashboard-services/dashboardController.test.mjs
@@ -1,0 +1,78 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let getDashboardController;
+let getDashboardService;
+let getCurrentSession;
+
+jest.unstable_mockModule("../../../src/functions/dashboard-services/dashboardService.mjs", () => ({
+  getDashboardService: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../../src/functions/auth-services/authService.mjs", () => ({
+  getCurrentSession: jest.fn(),
+}));
+
+beforeAll(async () => {
+  ({ getDashboardService } = await import(
+    "../../../src/functions/dashboard-services/dashboardService.mjs"
+  ));
+  ({ getCurrentSession } = await import("../../../src/functions/auth-services/authService.mjs"));
+  ({ getDashboardController } = await import(
+    "../../../src/functions/dashboard-services/dashboardController.mjs"
+  ));
+});
+
+describe("dashboardController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("retorna 401 si no recibe Authorization", async () => {
+    const result = await getDashboardController({ headers: {} });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(401);
+    expect(body.message).toBe("Token requerido");
+    expect(getCurrentSession).not.toHaveBeenCalled();
+  });
+
+  it("retorna 403 si el usuario no es admin", async () => {
+    getCurrentSession.mockResolvedValue({ role: "chofer" });
+
+    const result = await getDashboardController({
+      headers: { Authorization: "Bearer token" },
+    });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(403);
+    expect(body.message).toContain("Solo el Administrador");
+    expect(getDashboardService).not.toHaveBeenCalled();
+  });
+
+  it("retorna 200 con la data del dashboard para admin", async () => {
+    const dashboard = { kpis: { totalCamiones: 2 } };
+    getCurrentSession.mockResolvedValue({ role: "admin" });
+    getDashboardService.mockResolvedValue(dashboard);
+
+    const result = await getDashboardController({
+      headers: { authorization: "Bearer token" },
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual(dashboard);
+    expect(getCurrentSession).toHaveBeenCalledWith("Bearer token");
+  });
+
+  it("retorna 500 si falla la sesion o el servicio", async () => {
+    getCurrentSession.mockRejectedValue(new Error("Sesion invalida"));
+
+    const result = await getDashboardController({
+      headers: { Authorization: "Bearer token" },
+    });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(500);
+    expect(body.message).toBe("Error interno del servidor");
+  });
+});

--- a/__tests__/unit/dashboard-services/dashboardHandler.test.mjs
+++ b/__tests__/unit/dashboard-services/dashboardHandler.test.mjs
@@ -1,0 +1,32 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let handler;
+let getDashboardController;
+
+jest.unstable_mockModule("../../../src/functions/dashboard-services/dashboardController.mjs", () => ({
+  getDashboardController: jest.fn(),
+}));
+
+beforeAll(async () => {
+  ({ getDashboardController } = await import(
+    "../../../src/functions/dashboard-services/dashboardController.mjs"
+  ));
+  ({ handler } = await import("../../../src/functions/dashboard-services/dashboardHandler.mjs"));
+});
+
+describe("dashboardHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delega el evento al dashboard controller", async () => {
+    const event = { httpMethod: "GET", resource: "/dashboard" };
+    const expected = { statusCode: 200, body: "{}" };
+    getDashboardController.mockResolvedValue(expected);
+
+    const result = await handler(event);
+
+    expect(result).toBe(expected);
+    expect(getDashboardController).toHaveBeenCalledWith(event);
+  });
+});

--- a/__tests__/unit/dashboard-services/dashboardModel.test.mjs
+++ b/__tests__/unit/dashboard-services/dashboardModel.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "@jest/globals";
+import { buildDashboardResponse } from "../../../src/functions/dashboard-services/dashboardModel.mjs";
+
+describe("dashboardModel", () => {
+  it("construye respuesta con datos recibidos", () => {
+    const input = {
+      kpis: { totalCamiones: 3, contratosActivos: 2, alertasActivas: 1, ingresos: 1500 },
+      alertas: { alertasActivas: [{ id: "a1" }], contratosPorExpirar: [] },
+      graficas: { gps: [{ tipo_evento: "MOVIMIENTO", total: 2 }], camiones: [] },
+      topCamiones: [{ unidad: "u1", km: 50 }],
+      contratos: [{ id: "c1" }],
+    };
+
+    expect(buildDashboardResponse(input)).toEqual(input);
+  });
+
+  it("usa valores por defecto cuando faltan bloques", () => {
+    const result = buildDashboardResponse({});
+
+    expect(result.kpis).toEqual({
+      totalCamiones: 0,
+      contratosActivos: 0,
+      alertasActivas: 0,
+      ingresos: 0,
+    });
+    expect(result.alertas).toEqual({ alertasActivas: [], contratosPorExpirar: [] });
+    expect(result.graficas).toEqual({ gps: [], camiones: [] });
+    expect(result.topCamiones).toEqual([]);
+    expect(result.contratos).toEqual([]);
+  });
+});

--- a/__tests__/unit/dashboard-services/dashboardRepository.test.mjs
+++ b/__tests__/unit/dashboard-services/dashboardRepository.test.mjs
@@ -1,0 +1,112 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+const query = jest.fn();
+
+let repository;
+
+jest.unstable_mockModule("../../../src/shared/config/database.mjs", () => ({
+  query,
+}));
+
+beforeAll(async () => {
+  repository = await import("../../../src/functions/dashboard-services/dashboardRepository.mjs");
+});
+
+describe("dashboardRepository", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("getKPIs convierte contadores e ingresos a numeros", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ count: "5" }] })
+      .mockResolvedValueOnce({ rows: [{ count: "3" }] })
+      .mockResolvedValueOnce({ rows: [{ count: "2" }] })
+      .mockResolvedValueOnce({ rows: [{ total: "1200.50" }] });
+
+    const result = await repository.getKPIs();
+
+    expect(result).toEqual({
+      totalCamiones: 5,
+      contratosActivos: 3,
+      alertasActivas: 2,
+      ingresos: 1200.5,
+    });
+    expect(query).toHaveBeenCalledTimes(4);
+  });
+
+  it("getKPIs propaga errores de consulta", async () => {
+    query.mockRejectedValue(new Error("DB error"));
+
+    await expect(repository.getKPIs()).rejects.toThrow("DB error");
+  });
+
+  it("getAlertas mapea alertas activas y contratos por expirar", async () => {
+    query
+      .mockResolvedValueOnce({
+        rows: [{ id: "a1", tipo: "GPS", estado: "ACTIVA", severidad: "ALTA" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: "c1", cliente: "Cliente", tarifa: "900.00", fecha_fin: "2026-05-30" }],
+      });
+
+    const result = await repository.getAlertas();
+
+    expect(result.alertasActivas).toEqual([
+      { id: "a1", tipo: "GPS", estado: "ACTIVA", severidad: "ALTA" },
+    ]);
+    expect(result.contratosPorExpirar).toEqual([
+      { id: "c1", cliente: "Cliente", tarifa: 900, fecha_fin: "2026-05-30" },
+    ]);
+  });
+
+  it("getGraficas retorna agrupaciones numericas", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ tipo_evento: "MOVIMIENTO", total: "4" }] })
+      .mockResolvedValueOnce({ rows: [{ estado: "DISPONIBLE", total: "7" }] });
+
+    const result = await repository.getGraficas();
+
+    expect(result).toEqual({
+      gps: [{ tipo_evento: "MOVIMIENTO", total: 4 }],
+      camiones: [{ estado: "DISPONIBLE", total: 7 }],
+    });
+  });
+
+  it("getGraficas retorna arrays vacios si falla la consulta", async () => {
+    query.mockRejectedValue(new Error("DB error"));
+
+    const result = await repository.getGraficas();
+
+    expect(result).toEqual({ gps: [], camiones: [] });
+  });
+
+  it("getTopCamiones mapea kilometros por unidad", async () => {
+    query.mockResolvedValue({ rows: [{ unidad: "u1", km: "250.5" }] });
+
+    const result = await repository.getTopCamiones();
+
+    expect(result).toEqual([{ unidad: "u1", km: 250.5 }]);
+  });
+
+  it("getContratos mapea contratos activos", async () => {
+    query.mockResolvedValue({
+      rows: [{ id: "c1", cliente: "Cliente", tarifa: "1500.00", fecha_fin: "2026-06-01" }],
+    });
+
+    const result = await repository.getContratos();
+
+    expect(result).toEqual([
+      { id: "c1", cliente: "Cliente", tarifa: 1500, fecha_fin: "2026-06-01" },
+    ]);
+  });
+
+  it("getTopCamiones y getContratos propagan errores criticos", async () => {
+    query.mockRejectedValueOnce(new Error("Top error"));
+    await expect(repository.getTopCamiones()).rejects.toThrow("Top error");
+
+    query.mockRejectedValueOnce(new Error("Contratos error"));
+    await expect(repository.getContratos()).rejects.toThrow("Contratos error");
+  });
+});

--- a/__tests__/unit/dashboard-services/dashboardService.test.mjs
+++ b/__tests__/unit/dashboard-services/dashboardService.test.mjs
@@ -1,0 +1,70 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let getDashboardService;
+let buildDashboardResponse;
+let repository;
+
+jest.unstable_mockModule("../../../src/functions/dashboard-services/dashboardRepository.mjs", () => ({
+  getKPIs: jest.fn(),
+  getAlertas: jest.fn(),
+  getGraficas: jest.fn(),
+  getTopCamiones: jest.fn(),
+  getContratos: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../../src/functions/dashboard-services/dashboardModel.mjs", () => ({
+  buildDashboardResponse: jest.fn(),
+}));
+
+beforeAll(async () => {
+  repository = await import("../../../src/functions/dashboard-services/dashboardRepository.mjs");
+  ({ buildDashboardResponse } = await import(
+    "../../../src/functions/dashboard-services/dashboardModel.mjs"
+  ));
+  ({ getDashboardService } = await import(
+    "../../../src/functions/dashboard-services/dashboardService.mjs"
+  ));
+});
+
+describe("dashboardService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("obtiene todos los bloques y construye la respuesta consolidada", async () => {
+    const kpis = { totalCamiones: 4 };
+    const alertas = { alertasActivas: [], contratosPorExpirar: [] };
+    const graficas = { gps: [], camiones: [] };
+    const topCamiones = [{ unidad: "ABC-123", km: 100 }];
+    const contratos = [{ id: "contrato-1" }];
+    const expected = { kpis, alertas, graficas, topCamiones, contratos };
+
+    repository.getKPIs.mockResolvedValue(kpis);
+    repository.getAlertas.mockResolvedValue(alertas);
+    repository.getGraficas.mockResolvedValue(graficas);
+    repository.getTopCamiones.mockResolvedValue(topCamiones);
+    repository.getContratos.mockResolvedValue(contratos);
+    buildDashboardResponse.mockReturnValue(expected);
+
+    const result = await getDashboardService();
+
+    expect(result).toBe(expected);
+    expect(buildDashboardResponse).toHaveBeenCalledWith({
+      kpis,
+      alertas,
+      graficas,
+      topCamiones,
+      contratos,
+    });
+  });
+
+  it("propaga errores cuando una consulta critica falla", async () => {
+    repository.getKPIs.mockRejectedValue(new Error("DB error"));
+    repository.getAlertas.mockResolvedValue({});
+    repository.getGraficas.mockResolvedValue({});
+    repository.getTopCamiones.mockResolvedValue([]);
+    repository.getContratos.mockResolvedValue([]);
+
+    await expect(getDashboardService()).rejects.toThrow("DB error");
+  });
+});

--- a/__tests__/unit/shared-utils/camionValidator.test.mjs
+++ b/__tests__/unit/shared-utils/camionValidator.test.mjs
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "@jest/globals";
+import { CamionValidator } from "../../../src/shared/utils/validators/camionValidator.mjs";
+
+describe("CamionValidator", () => {
+  it("validateId normaliza ids numericos validos", () => {
+    expect(CamionValidator.validateId("15")).toBe(15);
+  });
+
+  it("validateId rechaza valores invalidos", () => {
+    expect(() => CamionValidator.validateId("0")).toThrow();
+    expect(() => CamionValidator.validateId("abc")).toThrow();
+  });
+
+  it("normaliza placa, marca, modelo y estado", () => {
+    expect(CamionValidator.validatePlaca(" abc-123 ")).toBe("ABC-123");
+    expect(CamionValidator.validateMarca(" Volvo ")).toBe("Volvo");
+    expect(CamionValidator.validateModelo(" FH ")).toBe("FH");
+    expect(CamionValidator.validateEstado("EN_USO")).toBe("en_uso");
+    expect(CamionValidator.validateEstado()).toBe("disponible");
+  });
+
+  it("rechaza campos de texto invalidos", () => {
+    expect(() => CamionValidator.validatePlaca(" ")).toThrow("La placa no puede estar");
+    expect(() => CamionValidator.validatePlaca(123)).toThrow("La placa debe ser texto");
+    expect(() => CamionValidator.validateMarca("")).toThrow("La marca es requerida");
+    expect(() => CamionValidator.validateMarca(123)).toThrow("La marca debe ser texto");
+    expect(() => CamionValidator.validateModelo("")).toThrow();
+    expect(() => CamionValidator.validateModelo(123)).toThrow("El modelo debe ser texto");
+    expect(() => CamionValidator.validateEstado("NO_EXISTE")).toThrow();
+  });
+
+  it("validateCreateCamion retorna datos normalizados", () => {
+    const result = CamionValidator.validateCreateCamion({
+      placa: " abc-123 ",
+      marca: " Volvo ",
+      modelo: " FH ",
+      estado: "Disponible",
+    });
+
+    expect(result).toEqual({
+      placa: "ABC-123",
+      marca: "Volvo",
+      modelo: "FH",
+      estado: "disponible",
+    });
+  });
+
+  it("validateCreateCamion acumula errores de validacion", () => {
+    expect(() =>
+      CamionValidator.validateCreateCamion({
+        placa: "",
+        marca: "",
+        modelo: "",
+        estado: "INVALIDO",
+      })
+    ).toThrow("Errores de validaci");
+  });
+
+  it("validateUpdateCamion permite cambios parciales y rechaza payload vacio", () => {
+    expect(CamionValidator.validateUpdateCamion({ placa: " xyz-999 " })).toEqual({
+      placa: "XYZ-999",
+    });
+
+    expect(() => CamionValidator.validateUpdateCamion({})).toThrow(
+      "No hay campos"
+    );
+  });
+
+  it("validateUpdateCamion acumula errores de campos presentes", () => {
+    expect(() =>
+      CamionValidator.validateUpdateCamion({
+        placa: "",
+        estado: "INVALIDO",
+      })
+    ).toThrow("Errores de validaci");
+  });
+
+  it("validateRequestBody parsea JSON y rechaza body invalido", () => {
+    expect(CamionValidator.validateRequestBody('{"placa":"ABC-123"}')).toEqual({
+      placa: "ABC-123",
+    });
+
+    expect(() => CamionValidator.validateRequestBody()).toThrow();
+    expect(() => CamionValidator.validateRequestBody("{bad-json")).toThrow();
+  });
+});

--- a/__tests__/unit/shared-utils/response.test.mjs
+++ b/__tests__/unit/shared-utils/response.test.mjs
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  createResponse,
+  successResponse,
+  errorResponse,
+} from "../../../src/shared/utils/response/response.mjs";
+
+describe("response utils", () => {
+  it("createResponse construye una respuesta con data opcional", () => {
+    const result = createResponse(201, true, "Creado", { id: "1" });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(201);
+    expect(result.headers["Access-Control-Allow-Origin"]).toBe("*");
+    expect(body).toEqual({ success: true, message: "Creado", data: { id: "1" } });
+  });
+
+  it("createResponse omite data cuando es null", () => {
+    const result = createResponse(204, true, "Sin contenido");
+    const body = JSON.parse(result.body);
+
+    expect(body).toEqual({ success: true, message: "Sin contenido" });
+  });
+
+  it("successResponse soporta mensaje, data y status code personalizados", () => {
+    const result = successResponse({ ok: true }, "OK", 202);
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(202);
+    expect(body).toEqual({ success: true, message: "OK", data: { ok: true } });
+  });
+
+  it("successResponse omite mensaje y data cuando son null", () => {
+    const result = successResponse();
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(200);
+    expect(body).toEqual({ success: true });
+  });
+
+  it("errorResponse construye errores con data opcional", () => {
+    const result = errorResponse("Fallo", 400, { campo: "placa" });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(400);
+    expect(body).toEqual({ success: false, message: "Fallo", data: { campo: "placa" } });
+  });
+});

--- a/__tests__/unit/unidad-services/unidadHandler.test.mjs
+++ b/__tests__/unit/unidad-services/unidadHandler.test.mjs
@@ -1,0 +1,55 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+let handler;
+let getAllDisponiblesController;
+
+jest.unstable_mockModule("../../../src/functions/unidad-services/unidadController.mjs", () => ({
+  getAllDisponiblesController: jest.fn(),
+}));
+
+beforeAll(async () => {
+  ({ getAllDisponiblesController } = await import(
+    "../../../src/functions/unidad-services/unidadController.mjs"
+  ));
+  ({ handler } = await import("../../../src/functions/unidad-services/unidadHandler.mjs"));
+});
+
+describe("unidadHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("enruta GET /unidades/disponibles al controller", async () => {
+    const expected = { statusCode: 200, body: JSON.stringify({ data: [] }) };
+    getAllDisponiblesController.mockResolvedValue(expected);
+
+    const result = await handler({ httpMethod: "GET", resource: "/unidades/disponibles" });
+
+    expect(result).toBe(expected);
+    expect(getAllDisponiblesController).toHaveBeenCalledWith({
+      httpMethod: "GET",
+      resource: "/unidades/disponibles",
+    });
+  });
+
+  it("retorna 404 si la ruta no existe", async () => {
+    const result = await handler({ httpMethod: "GET", resource: "/unidades" });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(404);
+    expect(body.success).toBe(false);
+    expect(body.message).toContain("Ruta GET /unidades no encontrada");
+  });
+
+  it("retorna 500 si el controller lanza error", async () => {
+    getAllDisponiblesController.mockRejectedValue(new Error("DB down"));
+
+    const result = await handler({ httpMethod: "GET", resource: "/unidades/disponibles" });
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.message).toBe("DB down");
+  });
+});

--- a/__tests__/unit/unidad-services/unidadModel.test.mjs
+++ b/__tests__/unit/unidad-services/unidadModel.test.mjs
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "@jest/globals";
+import { Unidad } from "../../../src/functions/unidad-services/unidadModel.mjs";
+
+describe("UnidadModel", () => {
+  const row = {
+    id: "uni-1",
+    placa: "ABC-123",
+    marca: "Volvo",
+    modelo: "FH",
+    anio: 2020,
+    capacidad_ton: "30.5",
+    estado: "DISPONIBLE",
+    activo: true,
+  };
+
+  it("crea una instancia desde una fila de base de datos", () => {
+    const unidad = Unidad.fromDatabase(row);
+
+    expect(unidad).toBeInstanceOf(Unidad);
+    expect(unidad).toMatchObject(row);
+  });
+
+  it("mapea listas desde filas de base de datos", () => {
+    const result = Unidad.fromDatabaseList([row]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(Unidad);
+    expect(result[0].placa).toBe("ABC-123");
+  });
+});

--- a/__tests__/unit/unidad-services/unidadRepository.test.mjs
+++ b/__tests__/unit/unidad-services/unidadRepository.test.mjs
@@ -1,0 +1,45 @@
+import { jest, describe, it, expect, beforeEach, beforeAll } from "@jest/globals";
+
+const dbMock = {
+  query: jest.fn(),
+};
+
+let UnidadRepository;
+
+jest.unstable_mockModule("../../../src/shared/config/database.mjs", () => ({
+  default: dbMock,
+}));
+
+beforeAll(async () => {
+  ({ UnidadRepository } = await import(
+    "../../../src/functions/unidad-services/unidadRepository.mjs"
+  ));
+});
+
+describe("UnidadRepository", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("consulta unidades disponibles activas ordenadas por placa", async () => {
+    const rows = [{ id: "uni-1", placa: "ABC-123", estado: "DISPONIBLE", activo: true }];
+    dbMock.query.mockResolvedValue({ rows });
+
+    const repository = new UnidadRepository();
+    const result = await repository.getAllDisponibles();
+
+    expect(result).toEqual(rows);
+    expect(dbMock.query).toHaveBeenCalledTimes(1);
+    expect(dbMock.query.mock.calls[0][0]).toContain("estado = 'DISPONIBLE'");
+    expect(dbMock.query.mock.calls[0][0]).toContain("activo = TRUE");
+    expect(dbMock.query.mock.calls[0][0]).toContain("ORDER BY placa");
+  });
+
+  it("propaga errores de base de datos", async () => {
+    dbMock.query.mockRejectedValue(new Error("DB error"));
+
+    const repository = new UnidadRepository();
+
+    await expect(repository.getAllDisponibles()).rejects.toThrow("DB error");
+  });
+});

--- a/db/migrations/1778288400000_align-cognito-login-users.sql
+++ b/db/migrations/1778288400000_align-cognito-login-users.sql
@@ -1,0 +1,67 @@
+-- migrate:up
+
+UPDATE usuarios
+SET cognito_sub = NULL
+WHERE cognito_sub IN (
+  '74f8c4f8-a041-70ca-4e30-e78b87d1cfdb',
+  'c4f84478-a051-707b-d0ee-ad4d95480a7c',
+  '744844e8-d051-70fb-a746-c22ccc07352a'
+)
+AND id NOT IN (
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222',
+  '55555555-5555-5555-5555-555555555555'
+);
+
+INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni, activo, estado)
+VALUES
+  ('11111111-1111-1111-1111-111111111111', '74f8c4f8-a041-70ca-4e30-e78b87d1cfdb', 'admin@nanutech.com', 'Jimena', 'Rodriguez', 'ADMIN', '999111222', '70000001', TRUE, 'ACTIVO'),
+  ('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer@nanutech.com', 'Carlos', 'Mendoza', 'CHOFER', '999222333', '70000002', TRUE, 'ACTIVO'),
+  ('55555555-5555-5555-5555-555555555555', '744844e8-d051-70fb-a746-c22ccc07352a', 'gerente@nanutech.com', 'Laura', 'Vasquez', 'GERENTE', '999777888', '70000005', TRUE, 'ACTIVO')
+ON CONFLICT (id) DO UPDATE SET
+  cognito_sub = EXCLUDED.cognito_sub,
+  correo = EXCLUDED.correo,
+  nombres = EXCLUDED.nombres,
+  apellidos = EXCLUDED.apellidos,
+  rol = EXCLUDED.rol,
+  telefono = EXCLUDED.telefono,
+  dni = EXCLUDED.dni,
+  activo = EXCLUDED.activo,
+  estado = EXCLUDED.estado;
+
+UPDATE auditoria_accesos
+SET correo = 'gerente@nanutech.com'
+WHERE usuario_id = '55555555-5555-5555-5555-555555555555'
+  AND correo = 'gerencia@nanutech.com';
+
+UPDATE password_reset_tokens
+SET correo = 'chofer@nanutech.com'
+WHERE usuario_id = '22222222-2222-2222-2222-222222222222'
+  AND correo = 'chofer1@nanutech.com';
+
+-- migrate:down
+
+UPDATE usuarios
+SET cognito_sub = '7438d4b8-0021-7065-dda7-7bbdfa75c929',
+    correo = 'admin@nanutech.com'
+WHERE id = '11111111-1111-1111-1111-111111111111';
+
+UPDATE usuarios
+SET cognito_sub = 'c4f84478-a051-707b-d0ee-ad4d95480a7c',
+    correo = 'chofer1@nanutech.com'
+WHERE id = '22222222-2222-2222-2222-222222222222';
+
+UPDATE usuarios
+SET cognito_sub = NULL,
+    correo = 'gerencia@nanutech.com'
+WHERE id = '55555555-5555-5555-5555-555555555555';
+
+UPDATE auditoria_accesos
+SET correo = 'gerencia@nanutech.com'
+WHERE usuario_id = '55555555-5555-5555-5555-555555555555'
+  AND correo = 'gerente@nanutech.com';
+
+UPDATE password_reset_tokens
+SET correo = 'chofer1@nanutech.com'
+WHERE usuario_id = '22222222-2222-2222-2222-222222222222'
+  AND correo = 'chofer@nanutech.com';

--- a/db/seed.mjs
+++ b/db/seed.mjs
@@ -4,11 +4,11 @@ export const seedSQL = `
 -- =========================================================
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', '7438d4b8-0021-7065-dda7-7bbdfa75c929', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('11111111-1111-1111-1111-111111111111', '74f8c4f8-a041-70ca-4e30-e78b87d1cfdb', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer@nanutech.com',   'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
 ('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002',               'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
 ('44444444-4444-4444-4444-444444444444', 'cognito-sub-chofer-003',               'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
-('55555555-5555-5555-5555-555555555555', NULL,                                   'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
+('55555555-5555-5555-5555-555555555555', '744844e8-d051-70fb-a746-c22ccc07352a', 'gerente@nanutech.com',  'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
 -- =========================================================
 -- CONDUCTORES
@@ -350,13 +350,13 @@ INSERT INTO auditoria_accesos (usuario_id, correo, rol, accion, resultado, ip_ad
 VALUES
 ('11111111-1111-1111-1111-111111111111', 'admin@nanutech.com',   'ADMIN',   'LOGIN',             'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Inicio de sesión correcto'),
 ('33333333-3333-3333-3333-333333333333', 'chofer2@nanutech.com', 'CHOFER',  'INICIAR_JORNADA',   'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Android',        'Jornada iniciada desde panel chofer'),
-('55555555-5555-5555-5555-555555555555', 'gerencia@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
+('55555555-5555-5555-5555-555555555555', 'gerente@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
 
 INSERT INTO login_intentos (email, intentos_fallidos, ultimo_intento, bloqueado_hasta)
 VALUES ('invalido@nanutech.com', 2, NOW() - INTERVAL '2 hours', NULL);
 
 INSERT INTO password_reset_tokens (usuario_id, email, token, expira_at, usado)
-VALUES ('22222222-2222-2222-2222-222222222222', 'chofer1@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
+VALUES ('22222222-2222-2222-2222-222222222222', 'chofer@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
 
 INSERT INTO sesiones_usuario (usuario_id, access_token_jti, refresh_token_jti, expira_at, ultimo_evento_at, estado)
 VALUES

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -3,11 +3,11 @@
 -- =========================================================
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', '7438d4b8-0021-7065-dda7-7bbdfa75c929', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('11111111-1111-1111-1111-111111111111', '74f8c4f8-a041-70ca-4e30-e78b87d1cfdb', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer@nanutech.com',   'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
 ('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002',               'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
 ('44444444-4444-4444-4444-444444444444', 'cognito-sub-chofer-003',               'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
-('55555555-5555-5555-5555-555555555555', NULL,                                   'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
+('55555555-5555-5555-5555-555555555555', '744844e8-d051-70fb-a746-c22ccc07352a', 'gerente@nanutech.com',  'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
 -- =========================================================
 -- CONDUCTORES
@@ -349,13 +349,13 @@ INSERT INTO auditoria_accesos (usuario_id, correo, rol, accion, resultado, ip_ad
 VALUES
 ('11111111-1111-1111-1111-111111111111', 'admin@nanutech.com',   'ADMIN',   'LOGIN',             'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Inicio de sesión correcto'),
 ('33333333-3333-3333-3333-333333333333', 'chofer2@nanutech.com', 'CHOFER',  'INICIAR_JORNADA',   'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Android',        'Jornada iniciada desde panel chofer'),
-('55555555-5555-5555-5555-555555555555', 'gerencia@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
+('55555555-5555-5555-5555-555555555555', 'gerente@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
 
 INSERT INTO login_intentos (email, intentos_fallidos, ultimo_intento, bloqueado_hasta)
 VALUES ('invalido@nanutech.com', 2, NOW() - INTERVAL '2 hours', NULL);
 
 INSERT INTO password_reset_tokens (usuario_id, email, token, expira_at, usado)
-VALUES ('22222222-2222-2222-2222-222222222222', 'chofer1@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
+VALUES ('22222222-2222-2222-2222-222222222222', 'chofer@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
 
 INSERT INTO sesiones_usuario (usuario_id, access_token_jti, refresh_token_jti, expira_at, ultimo_evento_at, estado)
 VALUES

--- a/db/seed/seed.sql
+++ b/db/seed/seed.sql
@@ -6,11 +6,11 @@ BEGIN;
 -- =========================================================
 INSERT INTO usuarios (id, cognito_sub, correo, nombres, apellidos, rol, telefono, dni)
 VALUES
-('11111111-1111-1111-1111-111111111111', '7438d4b8-0021-7065-dda7-7bbdfa75c929', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
-('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer1@nanutech.com',  'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
+('11111111-1111-1111-1111-111111111111', '74f8c4f8-a041-70ca-4e30-e78b87d1cfdb', 'admin@nanutech.com',    'Jimena', 'Rodriguez', 'ADMIN',   '999111222', '70000001'),
+('22222222-2222-2222-2222-222222222222', 'c4f84478-a051-707b-d0ee-ad4d95480a7c', 'chofer@nanutech.com',   'Carlos', 'Mendoza',   'CHOFER',  '999222333', '70000002'),
 ('33333333-3333-3333-3333-333333333333', 'cognito-sub-chofer-002',               'chofer2@nanutech.com',  'Luis',   'Ramirez',   'CHOFER',  '999333444', '70000003'),
 ('44444444-4444-4444-4444-444444444444', 'cognito-sub-chofer-003',               'chofer3@nanutech.com',  'Jorge',  'Silva',     'CHOFER',  '999444555', '70000004'),
-('55555555-5555-5555-5555-555555555555', NULL,                                   'gerencia@nanutech.com', 'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
+('55555555-5555-5555-5555-555555555555', '744844e8-d051-70fb-a746-c22ccc07352a', 'gerente@nanutech.com',  'Laura',  'Vasquez',   'GERENTE', '999777888', '70000005');
 
 -- =========================================================
 -- CONDUCTORES
@@ -352,13 +352,13 @@ INSERT INTO auditoria_accesos (usuario_id, correo, rol, accion, resultado, ip_ad
 VALUES
 ('11111111-1111-1111-1111-111111111111', 'admin@nanutech.com',   'ADMIN',   'LOGIN',             'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Inicio de sesión correcto'),
 ('33333333-3333-3333-3333-333333333333', 'chofer2@nanutech.com', 'CHOFER',  'INICIAR_JORNADA',   'EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Android',        'Jornada iniciada desde panel chofer'),
-('55555555-5555-5555-5555-555555555555', 'gerencia@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
+('55555555-5555-5555-5555-555555555555', 'gerente@nanutech.com','GERENTE', 'CONSULTA_DASHBOARD','EXITOSO', '127.0.0.1', 'Mozilla/5.0', 'Chrome Desktop', 'Consulta dashboard gerencial');
 
 INSERT INTO login_intentos (email, intentos_fallidos, ultimo_intento, bloqueado_hasta)
 VALUES ('invalido@nanutech.com', 2, NOW() - INTERVAL '2 hours', NULL);
 
 INSERT INTO password_reset_tokens (usuario_id, email, token, expira_at, usado)
-VALUES ('22222222-2222-2222-2222-222222222222', 'chofer1@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
+VALUES ('22222222-2222-2222-2222-222222222222', 'chofer@nanutech.com', 'RESET-TOKEN-001', NOW() + INTERVAL '1 day', FALSE);
 
 INSERT INTO sesiones_usuario (usuario_id, access_token_jti, refresh_token_jti, expira_at, ultimo_evento_at, estado)
 VALUES

--- a/docs/Sprint2/HU05_BACKEND_NOTES.md
+++ b/docs/Sprint2/HU05_BACKEND_NOTES.md
@@ -1,0 +1,72 @@
+# HU05 Backend Notes
+
+## Proposito
+HU05 implementa el seguimiento de jornadas laborales desde el modulo `jornada-services`, permitiendo consultar jornadas con informacion de conductor, unidad, contrato, horarios, duracion, estado y observaciones.
+
+## Modulo principal
+- `src/functions/jornada-services`
+
+## Archivos relacionados
+- `src/functions/jornada-services/jornadaHandler.mjs`
+- `src/functions/jornada-services/jornadaController.mjs`
+- `src/functions/jornada-services/jornadaService.mjs`
+- `src/functions/jornada-services/jornadaRepository.mjs`
+- `src/functions/jornada-services/jornadaModel.mjs`
+- `src/shared/utils/validators/jornadaValidator.mjs`
+- `__tests__/unit/jornada-services-test/jornadaHandler.test.mjs`
+- `__tests__/unit/jornada-services-test/jornadaController.test.mjs`
+- `__tests__/unit/jornada-services-test/jornadaService.test.mjs`
+- `__tests__/unit/jornada-services-test/jornadaRepository.test.mjs`
+
+## Endpoints disponibles
+- `GET /jornadas`
+- `GET /jornadas/exportar`
+
+## Funcionamiento actual
+- El handler recibe la combinacion `METHOD + resource` y redirige al controller correspondiente.
+- `GET /jornadas` valida la sesion con `getCurrentSession`.
+- El controller acepta filtros por:
+  - `q`
+  - `conductor_id`
+  - `fecha_desde`
+  - `fecha_hasta`
+- El repository arma filtros SQL parametrizados y consulta jornadas uniendo:
+  - `jornadas`
+  - `usuarios`
+  - `unidades`
+  - `contratos`
+- La respuesta incluye datos enriquecidos:
+  - fecha
+  - conductor
+  - camion
+  - contrato
+  - horario
+  - kilometros
+  - estado
+  - observaciones
+  - duracion total
+  - indicador `tiene_observaciones`
+- La duracion total se calcula desde SQL:
+  - con hora de fin: formato `HH:MM`
+  - en proceso: `En curso`
+  - registrada: `Sin iniciar`
+- Las jornadas se ordenan por `created_at DESC`.
+
+## Exportacion CSV
+- `GET /jornadas/exportar` usa los mismos filtros de listado.
+- El service genera el CSV con columnas de jornada, conductor, placa, contrato, horas, duracion, kilometros, estado y observaciones.
+- Los valores del CSV se escapan para soportar comas, comillas y saltos de linea.
+
+## Reglas aplicadas
+- Se valida que `fecha_desde` no sea mayor que `fecha_hasta`.
+- Todas las consultas usan parametros SQL para los filtros.
+- La vista de seguimiento usa datos ya enriquecidos desde el repository.
+
+## Pruebas relacionadas
+- Listado sin filtros.
+- Listado con busqueda por texto.
+- Filtro por conductor.
+- Filtro por rango de fechas.
+- Exportacion CSV sin filtros.
+- Exportacion CSV con filtros.
+- Escape correcto de valores CSV.

--- a/docs/Sprint2/HU06_BACKEND_NOTES.md
+++ b/docs/Sprint2/HU06_BACKEND_NOTES.md
@@ -1,0 +1,60 @@
+# HU06 Backend Notes
+
+## Proposito
+HU06 implementa el panel de gestion de contratos comerciales desde el modulo `contrato-services`, permitiendo consultar indicadores, contratos vigentes, listado paginado, busqueda y detalle de contrato.
+
+## Modulo principal
+- `src/functions/contrato-services`
+
+## Archivos relacionados
+- `src/functions/contrato-services/contratoHandler.mjs`
+- `src/functions/contrato-services/contratoController.mjs`
+- `src/functions/contrato-services/contratoService.mjs`
+- `src/functions/contrato-services/contratoRepository.mjs`
+- `src/functions/contrato-services/contratoModel.mjs`
+- `src/shared/utils/validators/contratoValidator.mjs`
+- `__tests__/unit/contrato-services/contratoHandler.test.mjs`
+- `__tests__/unit/contrato-services/contratoController.test.mjs`
+- `__tests__/unit/contrato-services/contratoService.test.mjs`
+- `__tests__/unit/contrato-services/contratoRepository.test.mjs`
+- `__tests__/unit/contrato-services/contratoModel.test.mjs`
+
+## Endpoints disponibles
+- `GET /contratos/indicadores`
+- `GET /contratos/vigentes`
+- `GET /contratos`
+- `GET /contratos/{id}`
+
+## Funcionamiento actual
+- El handler redirige cada ruta de contratos al controller correspondiente.
+- Los controllers validan sesion con `getCurrentSession` para las consultas principales.
+- `GET /contratos/indicadores` calcula metricas agregadas del modulo:
+  - total de contratos
+  - contratos activos
+  - contratos vencidos
+  - proximos a vencer
+  - camiones asignados
+  - distribucion por estado
+  - distribucion por tipo de servicio
+- `GET /contratos` permite listar contratos con:
+  - busqueda por codigo o cliente usando `q`
+  - filtro por `estado`
+  - paginacion con `page` y `limit`
+  - ordenamiento controlado con `order_by`
+- `GET /contratos/vigentes` retorna contratos activos con estado `VIGENTE` y fechas validas.
+- `GET /contratos/{id}` retorna el detalle del contrato con datos calculados y unidades asignadas.
+
+## Reglas aplicadas
+- El listado usa paginacion con limite controlado.
+- El ordenamiento usa una lista de campos permitidos para evitar ordenar por columnas no previstas.
+- La busqueda por texto se ejecuta con parametros SQL.
+- Los indicadores se calculan con consultas agregadas y JSON desde PostgreSQL.
+
+## Pruebas relacionadas
+- Consulta de contratos vigentes.
+- Indicadores del panel.
+- Listado paginado.
+- Busqueda por codigo o cliente.
+- Filtro por estado.
+- Detalle por ID.
+- Rutas del handler de contratos.

--- a/docs/Sprint2/HU07_BACKEND_NOTES.md
+++ b/docs/Sprint2/HU07_BACKEND_NOTES.md
@@ -1,0 +1,64 @@
+# HU07 Backend Notes
+
+## Proposito
+HU07 implementa operaciones de detalle y configuracion de contrato en `contrato-services`, incluyendo consulta del contrato seleccionado, actualizacion de campos configurables, actualizacion de tarifas, historial de cambios y asignacion de unidades.
+
+## Modulo principal
+- `src/functions/contrato-services`
+
+## Archivos relacionados
+- `src/functions/contrato-services/contratoHandler.mjs`
+- `src/functions/contrato-services/contratoController.mjs`
+- `src/functions/contrato-services/contratoService.mjs`
+- `src/functions/contrato-services/contratoRepository.mjs`
+- `src/functions/contrato-services/contratoModel.mjs`
+- `__tests__/unit/contrato-services/contratoController.test.mjs`
+- `__tests__/unit/contrato-services/contratoService.test.mjs`
+- `__tests__/unit/contrato-services/contratoRepository.test.mjs`
+
+## Endpoints manejados por el codigo
+- `GET /contratos/{id}`
+- `PUT /contratos/{id}`
+- `PUT /contratos/{id}/unidades`
+
+## Funcionamiento actual
+- `GET /contratos/{id}` obtiene el contrato por identificador y retorna informacion general, fechas, estado, datos calculados y unidades asociadas.
+- `PUT /contratos/{id}` lee el body JSON, captura la IP de la solicitud y delega la actualizacion al service.
+- `PUT /contratos/{id}/unidades` recibe una lista de unidades y delega la asignacion al service.
+
+## Actualizacion de contrato
+- El service obtiene el contrato actual antes de modificarlo.
+- Valida reglas basicas:
+  - fecha fin mayor o igual a fecha inicio
+  - tarifa mayor que cero
+  - descripcion con contenido cuando se envia
+- Registra historial cuando cambian:
+  - `fecha_fin`
+  - `tarifa`
+  - `descripcion`
+- Luego actualiza la tabla `contratos`.
+- Si se reciben tarifas, actualiza `contrato_tarifas`.
+
+## Historial
+- El repository registra cambios en `contratos_historial`.
+- Se guarda:
+  - contrato
+  - accion
+  - campo
+  - valor anterior
+  - valor nuevo
+  - IP
+
+## Asignacion de unidades
+- El service elimina asignaciones anteriores del contrato.
+- Luego inserta cada unidad recibida en `contrato_unidades`.
+
+## Pruebas relacionadas
+- Detalle de contrato por ID.
+- Contrato inexistente.
+- Validacion de ID requerido.
+- Actualizacion de contrato.
+- Registro de historial.
+- Actualizacion de tarifas.
+- Asignacion de unidades.
+- Eliminacion previa de unidades asignadas.

--- a/docs/Sprint2/HU08_BACKEND_NOTES.md
+++ b/docs/Sprint2/HU08_BACKEND_NOTES.md
@@ -1,0 +1,76 @@
+# HU08 Backend Notes
+
+## Proposito
+HU08 implementa la integracion GPS y la carga masiva de datos GPS desde el modulo `gps-services`, usando validacion CSV, proveedores configurados, importacion de registros, control de duplicados, errores de importacion y resumen operativo.
+
+## Modulo principal
+- `src/functions/gps-services`
+
+## Archivos relacionados
+- `src/functions/gps-services/gpsHandler.mjs`
+- `src/functions/gps-services/gpsController.mjs`
+- `src/functions/gps-services/gpsService.mjs`
+- `src/functions/gps-services/gpsRepository.mjs`
+- `src/functions/gps-services/gpsValidator.mjs`
+- `__tests__/unit/gps-services/gpsHandler.test.mjs`
+- `__tests__/unit/gps-services/gpsController.test.mjs`
+- `__tests__/unit/gps-services/gpsService.test.mjs`
+- `__tests__/unit/gps-services/gpsRepository.test.mjs`
+- `__tests__/unit/gps-services/gpsValidator.test.mjs`
+
+## Endpoints disponibles
+- `GET /gps/proveedores`
+- `GET /gps/plantilla`
+- `GET /gps/plantilla/{proveedor}`
+- `POST /gps/validar`
+- `POST /gps/importar`
+- `GET /gps/resumen`
+- `GET /gps/registros`
+
+## Proveedores soportados
+- `GPSCONTROL`
+- `GLOBALGPS`
+
+## Funcionamiento actual
+- `GET /gps/proveedores` retorna proveedores soportados, nombre visible y encabezados requeridos.
+- `GET /gps/plantilla` genera una plantilla CSV segun proveedor.
+- `POST /gps/validar` recibe contenido CSV, valida estructura y devuelve si la importacion queda habilitada.
+- `POST /gps/importar` procesa filas validas, registra cabecera de importacion, guarda errores y omite duplicados.
+- `GET /gps/resumen` calcula metricas desde los ultimos registros GPS por unidad.
+- `GET /gps/registros` lista registros GPS con filtros por proveedor y placa.
+
+## Validaciones CSV
+- Se valida extension `.csv`.
+- Se valida proveedor.
+- Se validan encabezados esperados.
+- Se validan columnas obligatorias.
+- Se valida fecha y hora.
+- Se validan rangos de latitud y longitud.
+- Se valida velocidad no negativa.
+- Se valida rumbo entre 0 y 360.
+- Se valida distancia total no negativa.
+
+## Estados GPS calculados
+- `MOVIENDO`: velocidad mayor a 5 km/h.
+- `DETENIDO`: velocidad menor o igual a 5 km/h.
+- `EXCESO_VELOCIDAD`: velocidad mayor al limite configurado.
+
+## Importacion
+- Se crea registro en `gps_importaciones`.
+- Se insertan filas validas en `gps_registros`.
+- Se registran errores en `gps_importacion_errores`.
+- Se verifica duplicado por proveedor, unidad y fecha/hora.
+- Se retorna conteo de importados, duplicados omitidos e invalidos.
+
+## Pruebas relacionadas
+- Proveedores GPS.
+- Plantillas GPSControl y GlobalGPS.
+- Validacion de CSV correcto.
+- Deteccion de columnas requeridas ausentes.
+- Validacion de coordenadas.
+- Validacion de velocidad.
+- Importacion de registros.
+- Omision de duplicados.
+- Registro de errores de importacion.
+- Resumen GPS.
+- Listado de registros GPS.

--- a/docs/Sprint2/HU11_BACKEND_NOTES.md
+++ b/docs/Sprint2/HU11_BACKEND_NOTES.md
@@ -1,0 +1,78 @@
+# HU11 Backend Notes
+
+## Proposito
+HU11 implementa el panel de monitoreo y gestion de camiones desde el modulo `camion-services`, permitiendo listar unidades, consultar detalle, registrar camiones, construir metricas del panel y exportar CSV.
+
+## Modulo principal
+- `src/functions/camion-services`
+
+## Archivos relacionados
+- `src/functions/camion-services/camionHandler.mjs`
+- `src/functions/camion-services/camionController.mjs`
+- `src/functions/camion-services/camionService.mjs`
+- `src/functions/camion-services/camionRepository.mjs`
+- `src/functions/camion-services/camionModel.mjs`
+- `__tests__/unit/camion-services/camionHandler.hu11.test.mjs`
+- `__tests__/unit/camion-services/camionController.hu11.test.mjs`
+- `__tests__/unit/camion-services/camionService.hu11.test.mjs`
+- `__tests__/unit/camion-services/camionRepository.hu11.test.mjs`
+- `__tests__/unit/camion-services/camionModel.hu11.test.mjs`
+
+## Endpoints disponibles
+- `GET /camiones`
+- `GET /camiones/{id}`
+- `POST /camiones`
+- `GET /camiones/panel`
+- `GET /camiones/exportar/csv`
+
+## Funcionamiento actual
+- `GET /camiones` lista unidades activas y puede filtrar por placa y estado.
+- `GET /camiones/{id}` obtiene una unidad por UUID y tambien soporta fallback ordinal cuando el ID recibido es numerico.
+- `POST /camiones` registra una nueva unidad con estado inicial `DISPONIBLE`.
+- `GET /camiones/panel` retorna resumen operativo, grafica de movimiento y listado de camiones.
+- `GET /camiones/exportar/csv` genera un CSV compatible con Excel.
+
+## Registro de camion
+- Se validan campos obligatorios:
+  - placa
+  - marca
+  - modelo
+  - anio
+  - capacidad
+  - VIN
+  - color
+  - combustible
+  - GPS
+- Se normaliza placa y VIN en mayusculas.
+- Se valida anio dentro de rango.
+- Se valida capacidad mayor que cero.
+- Se valida combustible contra catalogo interno.
+- Se valida duplicidad por placa y VIN.
+- El resultado incluye confirmacion con placa y modelo.
+
+## Panel de camiones
+- El repository consulta `unidades`.
+- Si existe `gps_registros`, agrega metricas GPS por unidad.
+- Calcula:
+  - total de camiones
+  - en uso
+  - disponibles
+  - mantenimiento
+  - horas en movimiento
+  - horas detenido
+  - porcentajes de movimiento y detenido
+- Para movimiento GPS usa velocidad mayor a 5 km/h.
+
+## Exportacion CSV
+- Exporta ID, placa, marca, modelo, anio, capacidad, estado, VIN, color, GPS, kilometraje, fecha de registro y mantenimiento.
+- Respeta los filtros enviados al panel.
+
+## Pruebas relacionadas
+- Ruteo de endpoints de camiones.
+- Listado con filtros.
+- Detalle por ID.
+- Registro correcto de camion.
+- Validaciones de placa, VIN, anio, capacidad y combustible.
+- Panel con metricas GPS.
+- Panel sin tabla GPS.
+- Exportacion CSV.

--- a/docs/Sprint2/HU12_BACKEND_NOTES.md
+++ b/docs/Sprint2/HU12_BACKEND_NOTES.md
@@ -1,0 +1,62 @@
+# HU12 Backend Notes
+
+## Proposito
+HU12 implementa un dashboard ejecutivo desde el modulo `dashboard-services`, orientado a indicadores generales, alertas, graficas, ranking de camiones y contratos activos.
+
+## Modulo principal
+- `src/functions/dashboard-services`
+
+## Archivos relacionados
+- `src/functions/dashboard-services/dashboardHandler.mjs`
+- `src/functions/dashboard-services/dashboardController.mjs`
+- `src/functions/dashboard-services/dashboardService.mjs`
+- `src/functions/dashboard-services/dashboardRepository.mjs`
+- `src/functions/dashboard-services/dashboardModel.mjs`
+- `__tests__/unit/dashboard-services/dashboardHandler.test.mjs`
+- `__tests__/unit/dashboard-services/dashboardController.test.mjs`
+- `__tests__/unit/dashboard-services/dashboardService.test.mjs`
+- `__tests__/unit/dashboard-services/dashboardRepository.test.mjs`
+- `__tests__/unit/dashboard-services/dashboardModel.test.mjs`
+
+## Endpoint disponible
+- `GET /dashboard`
+
+## Funcionamiento actual
+- El handler delega la solicitud al controller principal.
+- El controller valida que exista token `Authorization`.
+- La sesion se resuelve con `getCurrentSession`.
+- El acceso se permite para rol `admin`.
+- El service ejecuta consultas en paralelo para obtener:
+  - KPIs
+  - alertas
+  - graficas
+  - top de camiones
+  - contratos
+- El model arma una respuesta consolidada para el cliente.
+
+## KPIs
+- Total de camiones registrados.
+- Contratos activos por fecha.
+- Alertas activas.
+- Ingresos estimados desde contratos activos.
+
+## Alertas
+- Se consultan alertas activas desde `alertas_jornada`.
+- Se consultan contratos por expirar dentro de los proximos 30 dias.
+- La respuesta separa alertas activas y contratos por expirar.
+
+## Graficas
+- Eventos GPS agrupados por tipo.
+- Estados de camiones agrupados por estado.
+
+## Ranking y contratos
+- Top de camiones por kilometros recorridos.
+- Contratos activos ordenados por fecha de fin.
+
+## Pruebas relacionadas
+- Validacion de token requerido.
+- Control de acceso por rol admin.
+- Respuesta exitosa del dashboard.
+- Construccion de respuesta del model.
+- Consultas del repository.
+- Orquestacion paralela del service.

--- a/docs/Sprint2/HU14_BACKEND_NOTES.md
+++ b/docs/Sprint2/HU14_BACKEND_NOTES.md
@@ -1,0 +1,83 @@
+# HU14 Backend Notes
+
+## Proposito
+HU14 implementa el registro de nuevos contratos comerciales y sus reglas iniciales de tarifa desde el modulo `contrato-services`.
+
+## Modulo principal
+- `src/functions/contrato-services`
+
+## Archivos relacionados
+- `src/functions/contrato-services/contratoHandler.mjs`
+- `src/functions/contrato-services/contratoController.mjs`
+- `src/functions/contrato-services/contratoService.mjs`
+- `src/functions/contrato-services/contratoRepository.mjs`
+- `src/functions/contrato-services/contratoModel.mjs`
+- `src/shared/utils/validators/contratoValidator.mjs`
+- `__tests__/unit/contrato-services/contratoController.test.mjs`
+- `__tests__/unit/contrato-services/contratoService.test.mjs`
+- `__tests__/unit/contrato-services/contratoRepository.test.mjs`
+
+## Endpoint disponible
+- `POST /contratos`
+
+## Funcionamiento actual
+- El controller obtiene el token desde `Authorization`.
+- La sesion se valida con `getCurrentSession`.
+- El registro se permite para rol `gerente`.
+- El body JSON se parsea y se envia al service.
+- El service valida reglas de negocio con `ContratoValidator`.
+- El repository crea el contrato dentro de una transaccion.
+
+## Flujo de creacion
+1. Se inicia transaccion.
+2. Se genera codigo unico de contrato.
+3. Se calcula el total referencial.
+4. Se inserta el contrato principal.
+5. Se inserta la ruta del contrato.
+6. Se insertan tarifas del contrato.
+7. Se consulta el contrato completo creado.
+8. Se confirma la transaccion.
+
+## Datos registrados
+- Datos principales del contrato:
+  - codigo
+  - cliente
+  - RUC
+  - descripcion
+  - tipo de servicio
+  - fechas
+  - tarifa
+  - moneda
+  - estado
+- Ruta:
+  - origen
+  - destino
+  - distancia estimada
+- Tarifas:
+  - tarifa por kilometro
+  - tarifa por hora
+  - tarifa de espera
+  - total referencial
+
+## Calculo de tarifa
+- El total referencial se calcula como:
+  - `distancia_estimada_km * tarifa_por_km`
+- El resultado se redondea a 2 decimales.
+
+## Validaciones aplicadas
+- Cliente obligatorio.
+- RUC obligatorio con 11 digitos numericos.
+- Tipo de servicio obligatorio.
+- Fecha de inicio obligatoria.
+- Ruta obligatoria.
+- Distancia estimada valida.
+- Tarifa por kilometro valida.
+
+## Pruebas relacionadas
+- Registro de contrato valido.
+- Rechazo de RUC invalido.
+- Generacion de codigo.
+- Calculo de tarifa referencial.
+- Transaccion de creacion.
+- Rollback ante error.
+- Control de acceso por rol gerente.

--- a/docs/Sprint2/HU16_BACKEND_NOTES.md
+++ b/docs/Sprint2/HU16_BACKEND_NOTES.md
@@ -1,0 +1,92 @@
+# HU16 Backend Notes
+
+## Proposito
+HU16 implementa el dashboard gerencial desde el modulo `dashboard-gerencial-services`, consolidando resumen, graficas, operaciones, rendimiento e historial de jornadas para usuarios con rol gerencial o administrador.
+
+## Modulo principal
+- `src/functions/dashboard-gerencial-services`
+
+## Archivos relacionados
+- `src/functions/dashboard-gerencial-services/dashboardGerencialHandler.mjs`
+- `src/functions/dashboard-gerencial-services/dashboardGerencialController.mjs`
+- `src/functions/dashboard-gerencial-services/dashboardGerencialService.mjs`
+- `src/functions/dashboard-gerencial-services/dashboardGerencialRepository.mjs`
+- `src/functions/dashboard-gerencial-services/dashboardGerencialModel.mjs`
+- `__tests__/unit/dashboard-gerencial-services/dashboardGerencialHandler.test.mjs`
+- `__tests__/unit/dashboard-gerencial-services/dashboardGerencialController.test.mjs`
+- `__tests__/unit/dashboard-gerencial-services/dashboardGerencialService.test.mjs`
+- `__tests__/unit/dashboard-gerencial-services/dashboardGerencialRepository.test.mjs`
+- `__tests__/unit/dashboard-gerencial-services/dashboardGerencialModel.test.mjs`
+
+## Endpoint manejado por el codigo
+- `GET /dashboard/gerencial`
+
+## Funcionamiento actual
+- El handler recibe `GET /dashboard/gerencial` y llama al controller.
+- El controller valida token `Authorization`.
+- La sesion se resuelve con `getCurrentSession`.
+- El acceso se permite para roles:
+  - `gerente`
+  - `admin`
+- El controller lee filtros:
+  - `tiempo`
+  - `search`
+- El service consulta en paralelo:
+  - resumen
+  - graficas
+  - operaciones
+  - rendimiento
+  - historial
+- El model arma una respuesta con `success`, `data`, `estado_sistema` y `ultimo_actualizacion`.
+
+## Filtros de tiempo
+- `hoy`
+- `semana`
+- `mes`
+- `todas`
+
+## Resumen general
+- Total de jornadas.
+- Jornadas completadas.
+- Horas acumuladas.
+- Kilometros totales.
+- Eficiencia.
+- Flota activa.
+- Conductores activos.
+- Contratos activos.
+- Ingresos estimados.
+
+## Graficas
+- Jornadas por dia.
+- Kilometros por dia.
+- Sectores por estado de jornadas.
+- Sectores por estado de camiones.
+- Sectores por estado de conductores.
+
+## Operaciones
+- Jornadas en progreso o pendientes.
+- Camiones en mantenimiento.
+- Conductores disponibles.
+
+## Rendimiento
+- Top 5 conductores por kilometros.
+- Top 5 camiones por uso.
+
+## Historial
+- ID de jornada.
+- Conductor.
+- Camion.
+- Hora inicio.
+- Hora fin.
+- Kilometros recorridos.
+- Duracion en horas.
+- Estado.
+
+## Pruebas relacionadas
+- Ruteo del dashboard gerencial.
+- Token requerido.
+- Control de acceso para gerente/admin.
+- Respuesta exitosa con filtros.
+- Manejo de errores del controller.
+- Construccion de respuesta del model.
+- Consultas del repository.

--- a/src/functions/auth-services/authCognitoProvider.mjs
+++ b/src/functions/auth-services/authCognitoProvider.mjs
@@ -61,6 +61,7 @@ const getRoleFromClaims = (claims = {}, attributes = []) => {
 const buildNextRoute = (role) => {
   if (role === "admin") return "/dashboard/admin";
   if (role === "chofer") return "/dashboard/chofer";
+  if (role === "gerente") return "/dashboard/gerencial";
   return "/dashboard";
 };
 

--- a/src/functions/auth-services/authRepository.mjs
+++ b/src/functions/auth-services/authRepository.mjs
@@ -17,6 +17,14 @@ const initialUsers = [
     locked: false,
     resetCode: null,
   },
+  {
+    email: "gerente@test.com",
+    password: "123456",
+    role: "gerente",
+    attempts: 0,
+    locked: false,
+    resetCode: null,
+  },
 ];
 
 let users = initialUsers.map((user) => ({ ...user }));

--- a/src/functions/auth-services/authService.mjs
+++ b/src/functions/auth-services/authService.mjs
@@ -29,6 +29,7 @@ const createAuthError = (message, statusCode = 400, code = "AUTH_ERROR") => {
 const buildNextRoute = (role) => {
   if (role === "admin") return "/dashboard/admin";
   if (role === "chofer") return "/dashboard/chofer";
+  if (role === "gerente") return "/dashboard/gerencial";
   return "/dashboard";
 };
 

--- a/src/functions/contrato-services/contratoRepository.mjs
+++ b/src/functions/contrato-services/contratoRepository.mjs
@@ -491,7 +491,7 @@ export class ContratoRepository {
       WHERE c.id = $1
       GROUP BY c.id
       `,
-      [id]
+      [contratoId]
     );
 
     return result.rows[0] || null;


### PR DESCRIPTION
## Resumen
- Alinea usuarios seed con Cognito para login en nube.
- Agrega soporte local para login de gerente.
- Actualiza pruebas unitarias de auth y helpers de base en memoria.
- Agrega migración para sincronizar usuarios Cognito en bases existentes.
- Documenta el estado backend de las HU del Sprint 2 en `docs/Sprint2`.

## Validación
- `npm test`: 306 tests passed.
- Login local validado con `gerente@test.com / 123456`.
- Login Cognito del gerente cubierto por test usando el `cognito_sub` esperado.

## Notas
- No se modifica `template.yaml`.
- Nube mantiene Cognito como fuente real de autenticación.
- Local usa fallback con usuarios de prueba.
