### PR TITLE
fixHu12Cambio en el  manejo de errores internos con status 500

### DIFF
--- a/src/functions/contrato-services/contratoController.mjs
+++ b/src/functions/contrato-services/contratoController.mjs
@@ -109,7 +109,7 @@ export const createContratoController = async (event) => {
     console.error("Error en createContratoController:", error);
 
     // Retorna errores controlados de validación, autorización o procesamiento.
-    return errorResponse(error.message || "Error al registrar contrato", error.statusCode || 400, {
+    return errorResponse(error.message || "Error interno del servidor", error.statusCode || 500, {
       code: error.code || "CONTRATO_CREATE_ERROR",
     });
   }


### PR DESCRIPTION
## Cambios realizados
- Se corrigió el manejo de errores internos en `createContratoController`.
- Se actualizó la respuesta HTTP para retornar status `500` en errores internos del servidor.
- Se ajustó el flujo de validación y manejo de excepciones según observaciones del equipo QA.