### PR TITLE
HU19: Panel de Alertas y Emergencias — Endpoints Indicadores, Activas y Gestión de Estados (#248 #249)

### DIFF
--- a/__tests__/unit/alerta-services/alertaController.test.mjs
+++ b/__tests__/unit/alerta-services/alertaController.test.mjs
@@ -1,0 +1,221 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("../../../src/functions/auth-services/authService.mjs", () => ({
+  getCurrentSession: jest.fn().mockResolvedValue({
+    user: { id: "user-1", correo: "admin@nanutech.com" },
+    role: "gerente",
+    session: { id: "session-1" },
+  }),
+}));
+
+jest.unstable_mockModule("../../../src/functions/alerta-services/alertaService.mjs", () => ({
+  AlertaService: jest.fn().mockImplementation(() => ({
+    getIndicadores: jest.fn(),
+    getAlertasActivas: jest.fn(),
+    resolverAlerta: jest.fn(),
+    actualizarEstado: jest.fn(),
+  })),
+}));
+
+const {
+  getIndicadoresController,
+  getAlertasActivasController,
+  resolverAlertaController,
+  actualizarEstadoController,
+} = await import("../../../src/functions/alerta-services/alertaController.mjs");
+
+const { AlertaService } = await import("../../../src/functions/alerta-services/alertaService.mjs");
+const { getCurrentSession } = await import("../../../src/functions/auth-services/authService.mjs");
+
+const withAuth = (event = {}) => ({
+  ...event,
+  headers: {
+    Authorization: "Bearer fake-token-test",
+    ...(event.headers || {}),
+  },
+});
+
+describe("AlertaController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("getIndicadoresController retorna indicadores con status 200", async () => {
+    AlertaService.mockImplementation(() => ({
+      getIndicadores: jest.fn().mockResolvedValue({
+        panico_activas: 2,
+        auxilio_pendientes: 2,
+        total_resueltas: 12,
+        tiene_panico_activo: true,
+      }),
+    }));
+
+    const result = await getIndicadoresController(withAuth());
+
+    expect(result.statusCode).toBe(200);
+    expect(getCurrentSession).toHaveBeenCalledWith("Bearer fake-token-test");
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data.panico_activas).toBe(2);
+    expect(body.data.tiene_panico_activo).toBe(true);
+  });
+
+  test("getIndicadoresController retorna 401 sin token", async () => {
+    const authError = new Error("Token requerido");
+    authError.statusCode = 401;
+    authError.code = "TOKEN_REQUIRED";
+    getCurrentSession.mockRejectedValueOnce(authError);
+
+    const result = await getIndicadoresController({ headers: {} });
+
+    expect(result.statusCode).toBe(401);
+  });
+
+  test("getAlertasActivasController retorna lista con status 200", async () => {
+    AlertaService.mockImplementation(() => ({
+      getAlertasActivas: jest.fn().mockResolvedValue([
+        {
+          id: "alert-1",
+          codigo: "ALT-001",
+          tipo: "PANICO",
+          estado: "ACTIVA",
+          severidad: "CRITICA",
+          conductor: { id: "cond-1", nombre_completo: "Carlos Rodriguez" },
+          unidad: { id: "uni-1", placa: "ABC-123" },
+        },
+      ]),
+    }));
+
+    const result = await getAlertasActivasController(withAuth());
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data[0].tipo).toBe("PANICO");
+  });
+
+  test("getAlertasActivasController filtra por tipo", async () => {
+    const mockGetAlertasActivas = jest.fn().mockResolvedValue([]);
+    AlertaService.mockImplementation(() => ({
+      getAlertasActivas: mockGetAlertasActivas,
+    }));
+
+    await getAlertasActivasController(
+      withAuth({
+        queryStringParameters: { tipo: "AUXILIO_MECANICO" },
+      })
+    );
+
+    expect(mockGetAlertasActivas).toHaveBeenCalledWith(
+      expect.objectContaining({ tipo: "AUXILIO_MECANICO" })
+    );
+  });
+
+  test("resolverAlertaController resuelve alerta exitosamente", async () => {
+    AlertaService.mockImplementation(() => ({
+      resolverAlerta: jest.fn().mockResolvedValue({
+        id: "alert-1",
+        estado: "RESUELTA",
+        atendida: true,
+      }),
+    }));
+
+    const result = await resolverAlertaController(
+      withAuth({
+        pathParameters: { id: "alert-1" },
+        body: JSON.stringify({ detalle_resolucion: "Resuelto por técnico" }),
+      })
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data.estado).toBe("RESUELTA");
+  });
+
+  test("resolverAlertaController retorna 404 si alerta no existe", async () => {
+    AlertaService.mockImplementation(() => ({
+      resolverAlerta: jest.fn().mockRejectedValue({
+        message: "Alerta no encontrada.",
+        statusCode: 404,
+        code: "ALERTA_NOT_FOUND",
+      }),
+    }));
+
+    const result = await resolverAlertaController(
+      withAuth({
+        pathParameters: { id: "no-existe" },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(result.statusCode).toBe(404);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(false);
+  });
+
+  test("resolverAlertaController retorna 400 si ya está resuelta", async () => {
+    AlertaService.mockImplementation(() => ({
+      resolverAlerta: jest.fn().mockRejectedValue({
+        message: "La alerta ya fue resuelta.",
+        statusCode: 400,
+        code: "ALERTA_YA_RESUELTA",
+      }),
+    }));
+
+    const result = await resolverAlertaController(
+      withAuth({
+        pathParameters: { id: "alert-1" },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(false);
+  });
+
+  test("actualizarEstadoController cambia estado a EN_PROCESO", async () => {
+    AlertaService.mockImplementation(() => ({
+      actualizarEstado: jest.fn().mockResolvedValue({
+        id: "alert-1",
+        tipo: "AUXILIO_MECANICO",
+        estado: "EN_PROCESO",
+      }),
+    }));
+
+    const result = await actualizarEstadoController(
+      withAuth({
+        pathParameters: { id: "alert-1" },
+        body: JSON.stringify({ estado: "EN_PROCESO" }),
+      })
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data.estado).toBe("EN_PROCESO");
+  });
+
+  test("actualizarEstadoController retorna 400 si no es AUXILIO_MECANICO", async () => {
+    AlertaService.mockImplementation(() => ({
+      actualizarEstado: jest.fn().mockRejectedValue({
+        message: "Solo aplica para auxilios mecánicos.",
+        statusCode: 400,
+        code: "SOLO_AUXILIO_MECANICO",
+      }),
+    }));
+
+    const result = await actualizarEstadoController(
+      withAuth({
+        pathParameters: { id: "alert-1" },
+        body: JSON.stringify({ estado: "EN_PROCESO" }),
+      })
+    );
+
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(false);
+  });
+});

--- a/__tests__/unit/alerta-services/alertaHandler.test.mjs
+++ b/__tests__/unit/alerta-services/alertaHandler.test.mjs
@@ -1,0 +1,75 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("../../../src/functions/alerta-services/alertaController.mjs", () => ({
+  getIndicadoresController: jest.fn().mockResolvedValue({ statusCode: 200, body: "{}" }),
+  getAlertasActivasController: jest.fn().mockResolvedValue({ statusCode: 200, body: "{}" }),
+  resolverAlertaController: jest.fn().mockResolvedValue({ statusCode: 200, body: "{}" }),
+  actualizarEstadoController: jest.fn().mockResolvedValue({ statusCode: 200, body: "{}" }),
+}));
+
+const { handler } = await import("../../../src/functions/alerta-services/alertaHandler.mjs");
+const alertaController = await import("../../../src/functions/alerta-services/alertaController.mjs");
+
+describe("AlertaHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("rutea GET /alertas/indicadores a getIndicadoresController", async () => {
+    const event = {
+      httpMethod: "GET",
+      resource: "/alertas/indicadores",
+    };
+
+    await handler(event);
+
+    expect(alertaController.getIndicadoresController).toHaveBeenCalledWith(event);
+  });
+
+  test("rutea GET /alertas/activas a getAlertasActivasController", async () => {
+    const event = {
+      httpMethod: "GET",
+      resource: "/alertas/activas",
+    };
+
+    await handler(event);
+
+    expect(alertaController.getAlertasActivasController).toHaveBeenCalledWith(event);
+  });
+
+  test("rutea PATCH /alertas/{id}/resolver a resolverAlertaController", async () => {
+    const event = {
+      httpMethod: "PATCH",
+      resource: "/alertas/{id}/resolver",
+    };
+
+    await handler(event);
+
+    expect(alertaController.resolverAlertaController).toHaveBeenCalledWith(event);
+  });
+
+  test("rutea PATCH /alertas/{id}/estado a actualizarEstadoController", async () => {
+    const event = {
+      httpMethod: "PATCH",
+      resource: "/alertas/{id}/estado",
+    };
+
+    await handler(event);
+
+    expect(alertaController.actualizarEstadoController).toHaveBeenCalledWith(event);
+  });
+
+  test("retorna 404 para ruta no registrada", async () => {
+    const event = {
+      httpMethod: "DELETE",
+      resource: "/alertas/no-existe",
+    };
+
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(404);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(false);
+    expect(body.message).toBe("Ruta no encontrada");
+  });
+});

--- a/__tests__/unit/alerta-services/alertaRepository.test.mjs
+++ b/__tests__/unit/alerta-services/alertaRepository.test.mjs
@@ -1,0 +1,124 @@
+import { jest } from "@jest/globals";
+
+const mockQuery = jest.fn();
+const mockRelease = jest.fn();
+
+jest.unstable_mockModule("../../../src/shared/config/database.mjs", () => ({
+  getClient: jest.fn().mockResolvedValue({
+    query: mockQuery,
+    release: mockRelease,
+  }),
+}));
+
+const { AlertaRepository } = await import("../../../src/functions/alerta-services/alertaRepository.mjs");
+const { getClient } = await import("../../../src/shared/config/database.mjs");
+
+describe("AlertaRepository", () => {
+  let repository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new AlertaRepository();
+  });
+
+  test("getIndicadores ejecuta query correcta", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          panico_activas: "2",
+          auxilio_pendientes: "2",
+          total_resueltas: "12",
+          tiene_panico_activo: true,
+        },
+      ],
+    });
+
+    const result = await repository.getIndicadores();
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockRelease).toHaveBeenCalled();
+    const queryArg = mockQuery.mock.calls[0][0];
+    expect(queryArg).toContain("COUNT(CASE WHEN tipo = 'PANICO'");
+    expect(mockQuery.mock.calls[0][1]).toBeUndefined();
+    expect(result.panico_activas).toBe(2);
+    expect(result.tiene_panico_activo).toBe(true);
+  });
+
+  test("findActivas construye WHERE dinámico con filtros", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findActivas({ tipo: "PANICO", estado: "ACTIVA" });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("a.tipo = $1"),
+      expect.arrayContaining(["PANICO", "ACTIVA"])
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("a.estado = $2"),
+      expect.anything()
+    );
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  test("findActivas sin filtros retorna todo", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findActivas();
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("a.estado IN ('ACTIVA', 'EN_PROCESO')"),
+      []
+    );
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  test("resolverAlerta actualiza campos correctos", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          id: "alert-1",
+          estado: "RESUELTA",
+          atendida: true,
+          detalle_resolucion: "Cambio de batería",
+          servicio_tecnico_realizado: "Técnico A",
+        },
+      ],
+    });
+
+    const result = await repository.resolverAlerta("alert-1", {
+      detalle_resolucion: "Cambio de batería",
+      servicio_tecnico_realizado: "Técnico A",
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("estado = 'RESUELTA'"),
+      expect.anything()
+    );
+    expect(result.estado).toBe("RESUELTA");
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  test("actualizarEstado actualiza estado correctamente", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ id: "alert-1", estado: "EN_PROCESO" }],
+    });
+
+    const result = await repository.actualizarEstado("alert-1", "EN_PROCESO");
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("estado = $2"),
+      ["alert-1", "EN_PROCESO"]
+    );
+    expect(result.estado).toBe("EN_PROCESO");
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  test("findById retorna null si no existe", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const result = await repository.findById("no-existe");
+
+    expect(result).toBeNull();
+    expect(mockRelease).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/alerta-services/alertaService.test.mjs
+++ b/__tests__/unit/alerta-services/alertaService.test.mjs
@@ -1,0 +1,125 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("../../../src/functions/alerta-services/alertaRepository.mjs", () => ({
+  AlertaRepository: jest.fn().mockImplementation(() => ({
+    getIndicadores: jest.fn(),
+    findActivas: jest.fn(),
+    findById: jest.fn(),
+    resolverAlerta: jest.fn(),
+    actualizarEstado: jest.fn(),
+  })),
+}));
+
+const { AlertaService } = await import("../../../src/functions/alerta-services/alertaService.mjs");
+
+const buildAlertaRow = (overrides = {}) => ({
+  id: "alert-1",
+  codigo: "ALT-001",
+  jornada_id: "jor-1",
+  tipo: "AUXILIO_MECANICO",
+  estado: "ACTIVA",
+  severidad: "ALTA",
+  detalle: "Falla de motor",
+  tipo_falla_mecanica: "Sobrecalentamiento",
+  latitud: -12.0264,
+  longitud: -76.9916,
+  direccion: "Av. Principal 123",
+  fecha_hora: "2026-04-07T11:53:30.000Z",
+  bloqueo_sos_activo: false,
+  conductor_id: "cond-1",
+  conductor_nombre_completo: "Carlos Rodriguez",
+  conductor_telefono: "999111222",
+  conductor_dni: "70000001",
+  unidad_id: "uni-1",
+  unidad_placa: "ABC-123",
+  unidad_marca: "Volvo",
+  unidad_modelo: "FH16",
+  ...overrides,
+});
+
+describe("AlertaService", () => {
+  let alertaService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    alertaService = new AlertaService();
+  });
+
+  test("getIndicadores retorna objeto con 4 campos", async () => {
+    alertaService.repository.getIndicadores.mockResolvedValue({
+      panico_activas: 2,
+      auxilio_pendientes: 2,
+      total_resueltas: 12,
+      tiene_panico_activo: true,
+    });
+
+    const result = await alertaService.getIndicadores();
+
+    expect(alertaService.repository.getIndicadores).toHaveBeenCalled();
+    expect(result).toHaveProperty("panico_activas", 2);
+    expect(result).toHaveProperty("auxilio_pendientes", 2);
+    expect(result).toHaveProperty("total_resueltas", 12);
+    expect(result).toHaveProperty("tiene_panico_activo", true);
+  });
+
+  test("getAlertasActivas retorna lista filtrada", async () => {
+    alertaService.repository.findActivas.mockResolvedValue([
+      buildAlertaRow({ tipo: "PANICO", estado: "ACTIVA" }),
+      buildAlertaRow({ id: "alert-2", tipo: "AUXILIO_MECANICO", estado: "EN_PROCESO" }),
+    ]);
+
+    const result = await alertaService.getAlertasActivas({ tipo: "PANICO" });
+
+    expect(alertaService.repository.findActivas).toHaveBeenCalledWith({ tipo: "PANICO" });
+    expect(result).toHaveLength(2);
+    expect(result[0].tipo).toBe("PANICO");
+  });
+
+  test("resolverAlerta lanza error si no existe", async () => {
+    alertaService.repository.findById.mockResolvedValue(null);
+
+    await expect(alertaService.resolverAlerta("no-existe")).rejects.toMatchObject({
+      message: "Alerta no encontrada.",
+      statusCode: 404,
+      code: "ALERTA_NOT_FOUND",
+    });
+  });
+
+  test("resolverAlerta lanza error si ya está resuelta", async () => {
+    alertaService.repository.findById.mockResolvedValue(
+      buildAlertaRow({ estado: "RESUELTA" })
+    );
+
+    await expect(alertaService.resolverAlerta("alert-1")).rejects.toMatchObject({
+      message: "La alerta ya fue resuelta.",
+      statusCode: 400,
+      code: "ALERTA_YA_RESUELTA",
+    });
+  });
+
+  test("actualizarEstado lanza error si tipo no es AUXILIO_MECANICO", async () => {
+    alertaService.repository.findById.mockResolvedValue(
+      buildAlertaRow({ tipo: "PANICO", estado: "ACTIVA" })
+    );
+
+    await expect(alertaService.actualizarEstado("alert-1", "EN_PROCESO")).rejects.toMatchObject({
+      message: "Solo aplica para auxilios mecánicos.",
+      statusCode: 400,
+      code: "SOLO_AUXILIO_MECANICO",
+    });
+  });
+
+  test("actualizarEstado actualiza estado correctamente", async () => {
+    alertaService.repository.findById.mockResolvedValue(
+      buildAlertaRow({ tipo: "AUXILIO_MECANICO", estado: "ACTIVA" })
+    );
+    alertaService.repository.actualizarEstado.mockResolvedValue(
+      buildAlertaRow({ estado: "EN_PROCESO" })
+    );
+
+    const result = await alertaService.actualizarEstado("alert-1", "EN_PROCESO");
+
+    expect(alertaService.repository.actualizarEstado).toHaveBeenCalledWith("alert-1", "EN_PROCESO");
+    expect(result.estado).toBe("EN_PROCESO");
+  });
+});

--- a/src/functions/alerta-services/alertaController.mjs
+++ b/src/functions/alerta-services/alertaController.mjs
@@ -1,0 +1,167 @@
+import { AlertaService } from "./alertaService.mjs";
+import { successResponse, errorResponse } from "../../shared/utils/response/response.mjs";
+import { getCurrentSession } from "../auth-services/authService.mjs";
+
+/**
+ * Parsea el body del evento Lambda como JSON.
+ *
+ * @param {Object} event - Evento de AWS Lambda
+ * @returns {Object} Objeto parseado o vacío si no hay body
+ * @throws {Error} Con statusCode 400 si el body no es JSON válido
+ */
+function parseJsonBody(event) {
+  if (!event.body) return {};
+
+  try {
+    return JSON.parse(event.body);
+  } catch {
+    const error = new Error("El cuerpo de la solicitud no es un JSON válido.");
+    error.statusCode = 400;
+    error.code = "INVALID_REQUEST_BODY";
+    throw error;
+  }
+}
+
+/**
+ * Construye una respuesta de error estandarizada para el módulo de alertas.
+ * Infiere el statusCode desde el error o desde palabras clave del mensaje.
+ *
+ * @param {Error} error - Error capturado con propiedades opcionales statusCode y code
+ * @returns {Object} Respuesta HTTP con formato { success, message, statusCode }
+ */
+function resolveErrorResponse(error) {
+  const statusCode =
+    error.statusCode || (/(requerido|inv[aá]lido|validaci[oó]n)/i.test(error.message) ? 400 : 500);
+
+  return errorResponse(error.message, statusCode, {
+    code: error.code || "ALERTA_ERROR",
+  });
+}
+
+/**
+ * Obtiene los indicadores agregados del panel de alertas.
+ * Requiere autenticación Bearer válida.
+ *
+ * @param {Object} event - Evento de AWS Lambda
+ * @param {Object} event.headers - Headers HTTP de la solicitud
+ * @param {string} [event.headers.Authorization] - Token Bearer de autenticación
+ * @returns {Promise<Object>} Respuesta HTTP 200 con los 4 indicadores
+ * @throws {Error} 401 si el token es inválido o está ausente
+ */
+export const getIndicadoresController = async (event) => {
+  try {
+    const authorizationHeader = event.headers?.Authorization || event.headers?.authorization;
+    await getCurrentSession(authorizationHeader);
+
+    const alertaService = new AlertaService();
+    const indicadores = await alertaService.getIndicadores();
+
+    return successResponse(indicadores, "Indicadores de alertas obtenidos exitosamente.");
+  } catch (error) {
+    console.error("Error en getIndicadoresController:", error);
+    return resolveErrorResponse(error);
+  }
+};
+
+/**
+ * Obtiene todas las alertas activas (no resueltas) con sus relaciones
+ * de conductor y unidad. Permite filtrar por tipo y estado via query params.
+ * Requiere autenticación Bearer válida.
+ *
+ * @param {Object} event - Evento de AWS Lambda
+ * @param {Object} event.headers - Headers HTTP de la solicitud
+ * @param {string} [event.headers.Authorization] - Token Bearer de autenticación
+ * @param {Object} [event.queryStringParameters] - Query parameters opcionales
+ * @param {string} [event.queryStringParameters.tipo] - PANICO | AUXILIO_MECANICO | OBSERVACION
+ * @param {string} [event.queryStringParameters.estado] - ACTIVA | EN_PROCESO
+ * @returns {Promise<Object>} Respuesta HTTP 200 con lista de alertas
+ * @throws {Error} 401 si el token es inválido o está ausente
+ */
+export const getAlertasActivasController = async (event) => {
+  try {
+    const authorizationHeader = event.headers?.Authorization || event.headers?.authorization;
+    await getCurrentSession(authorizationHeader);
+
+    const { tipo, estado } = event.queryStringParameters || {};
+    const alertaService = new AlertaService();
+    const alertas = await alertaService.getAlertasActivas({ tipo, estado });
+
+    return successResponse(alertas, "Alertas activas obtenidas exitosamente.");
+  } catch (error) {
+    console.error("Error en getAlertasActivasController:", error);
+    return resolveErrorResponse(error);
+  }
+};
+
+/**
+ * Resuelve una alerta de emergencia, cambiando su estado a RESUELTA.
+ * Opcionalmente persiste detalle de resolución y servicio técnico.
+ * Requiere autenticación Bearer válida.
+ *
+ * @param {Object} event - Evento de AWS Lambda
+ * @param {Object} event.headers - Headers HTTP de la solicitud
+ * @param {string} [event.headers.Authorization] - Token Bearer de autenticación
+ * @param {Object} event.pathParameters - Parámetros de ruta
+ * @param {string} event.pathParameters.id - UUID de la alerta a resolver
+ * @param {string} event.body - JSON con datos opcionales de resolución
+ * @param {string} [event.body.detalle_resolucion] - Descripción de la resolución
+ * @param {string} [event.body.servicio_tecnico_realizado] - Servicio técnico aplicado
+ * @returns {Promise<Object>} Respuesta HTTP 200 con la alerta actualizada
+ * @throws {Error} 401 si el token es inválido o está ausente
+ * @throws {Error} 404 ALERTA_NOT_FOUND si la alerta no existe
+ * @throws {Error} 400 ALERTA_YA_RESUELTA si la alerta ya está resuelta
+ */
+export const resolverAlertaController = async (event) => {
+  try {
+    const authorizationHeader = event.headers?.Authorization || event.headers?.authorization;
+    await getCurrentSession(authorizationHeader);
+
+    const id = event.pathParameters?.id;
+    const body = parseJsonBody(event);
+    const alertaService = new AlertaService();
+    const alerta = await alertaService.resolverAlerta(id, {
+      detalle_resolucion: body.detalle_resolucion,
+      servicio_tecnico_realizado: body.servicio_tecnico_realizado,
+    });
+
+    return successResponse(alerta, "Alerta resuelta exitosamente.");
+  } catch (error) {
+    console.error("Error en resolverAlertaController:", error);
+    return resolveErrorResponse(error);
+  }
+};
+
+/**
+ * Actualiza el estado operativo de una alerta de auxilio mecánico.
+ * Solo aplica para alertas de tipo AUXILIO_MECANICO.
+ * Requiere autenticación Bearer válida.
+ *
+ * @param {Object} event - Evento de AWS Lambda
+ * @param {Object} event.headers - Headers HTTP de la solicitud
+ * @param {string} [event.headers.Authorization] - Token Bearer de autenticación
+ * @param {Object} event.pathParameters - Parámetros de ruta
+ * @param {string} event.pathParameters.id - UUID de la alerta
+ * @param {string} event.body - JSON con el nuevo estado
+ * @param {string} event.body.estado - EN_PROCESO | RESUELTA
+ * @returns {Promise<Object>} Respuesta HTTP 200 con la alerta actualizada
+ * @throws {Error} 401 si el token es inválido o está ausente
+ * @throws {Error} 404 ALERTA_NOT_FOUND si la alerta no existe
+ * @throws {Error} 400 SOLO_AUXILIO_MECANICO si el tipo no es AUXILIO_MECANICO
+ * @throws {Error} 400 ESTADO_INVALIDO si el estado no es permitido
+ */
+export const actualizarEstadoController = async (event) => {
+  try {
+    const authorizationHeader = event.headers?.Authorization || event.headers?.authorization;
+    await getCurrentSession(authorizationHeader);
+
+    const id = event.pathParameters?.id;
+    const body = parseJsonBody(event);
+    const alertaService = new AlertaService();
+    const alerta = await alertaService.actualizarEstado(id, body.estado);
+
+    return successResponse(alerta, "Estado actualizado exitosamente.");
+  } catch (error) {
+    console.error("Error en actualizarEstadoController:", error);
+    return resolveErrorResponse(error);
+  }
+};

--- a/src/functions/alerta-services/alertaHandler.mjs
+++ b/src/functions/alerta-services/alertaHandler.mjs
@@ -1,0 +1,49 @@
+import * as alertaController from "./alertaController.mjs";
+import { errorResponse } from "../../shared/utils/response/response.mjs";
+
+/**
+ * Tabla de rutas del módulo de alertas.
+ * Mapea cada combinación "METHOD /ruta" al controller correspondiente.
+ * El orden es importante: rutas más específicas deben ir antes de las
+ * genéricas para evitar colisiones en el ruteo del API Gateway.
+ *
+ * @type {Object.<string, Function>}
+ */
+const ROUTES = {
+  "GET /alertas/indicadores": alertaController.getIndicadoresController,
+  "GET /alertas/activas": alertaController.getAlertasActivasController,
+  "PATCH /alertas/{id}/resolver": alertaController.resolverAlertaController,
+  "PATCH /alertas/{id}/estado": alertaController.actualizarEstadoController,
+};
+
+/**
+ * Handler principal de AWS Lambda para el módulo de alertas.
+ * Construye la clave de ruta combinando método HTTP y recurso, busca el controller
+ * en ROUTES y delega la ejecución. Retorna 404 si la combinación no está registrada.
+ *
+ * Soporta API Gateway v1 (httpMethod + resource) y v2 (requestContext.http.method + rawPath).
+ *
+ * @param {Object} event - Evento de AWS Lambda (API Gateway v1 o v2)
+ * @param {Object} [event.requestContext] - Contexto de la solicitud
+ * @param {Object} [event.requestContext.http] - Contexto HTTP (API Gateway v2)
+ * @param {string} [event.requestContext.http.method] - Método HTTP en formato v2
+ * @param {string} [event.httpMethod] - Método HTTP en formato v1 (GET, POST, etc.)
+ * @param {string} [event.resource] - Recurso de la ruta en v1 (ej. /alertas/{id}/resolver)
+ * @param {string} [event.rawPath] - Ruta cruda en v2 (ej. /alertas/indicadores)
+ * @returns {Promise<Object>} Respuesta HTTP con formato { statusCode, headers, body }
+ */
+export const handler = async (event) => {
+  const method = event.requestContext?.http?.method || event.httpMethod;
+  const resource = event.resource || event.rawPath;
+  const routeKey = `${method} ${resource}`;
+
+  const routeHandler = ROUTES[routeKey];
+
+  if (!routeHandler) {
+    return errorResponse("Ruta no encontrada", 404, {
+      code: "ROUTE_NOT_FOUND",
+    });
+  }
+
+  return routeHandler(event);
+};

--- a/src/functions/alerta-services/alertaModel.mjs
+++ b/src/functions/alerta-services/alertaModel.mjs
@@ -1,0 +1,140 @@
+/**
+ * Modelo de dominio para la entidad Alerta del panel de emergencias.
+ * Representa una fila de la tabla alertas_jornada con sus relaciones
+ * anidadas a conductor y unidad.
+ *
+ * @module alertaModel
+ */
+
+/**
+ * Representa una alerta de emergencia dentro del sistema de jornadas.
+ * Incluye metadatos de ubicación, estado operativo, severidad y
+ * relaciones con conductor y unidad.
+ */
+export class Alerta {
+  /**
+   * Crea una instancia de Alerta.
+   *
+   * @param {Object} data - Datos brutos de la alerta
+   * @param {string} data.id - UUID de la alerta
+   * @param {string} [data.codigo] - Código legible (ej. ALT-001)
+   * @param {string} data.jornada_id - UUID de la jornada asociada
+   * @param {string} data.tipo - Tipo de alerta (PANICO | AUXILIO_MECANICO | OBSERVACION)
+   * @param {string} data.estado - Estado operativo (ACTIVA | EN_PROCESO | RESUELTA | FALSA_ALARMA)
+   * @param {string} data.severidad - Severidad (BAJA | MEDIA | ALTA | CRITICA)
+   * @param {string} [data.detalle] - Descripción libre de la alerta
+   * @param {string} [data.tipo_falla_mecanica] - Clasificación de falla cuando aplica
+   * @param {number} data.latitud - Latitud geográfica (-90 a 90)
+   * @param {number} data.longitud - Longitud geográfica (-180 a 180)
+   * @param {string} [data.direccion] - Dirección textual aproximada
+   * @param {string} data.fecha_hora - ISO 8601 del momento de la alerta
+   * @param {boolean} data.bloqueo_sos_activo - Indica si el SOS sigue activo
+   * @param {Object} [data.conductor] - Datos del conductor anidados
+   * @param {string} [data.conductor.id] - UUID del conductor
+   * @param {string} [data.conductor.nombre_completo] - Nombres y apellidos concatenados
+   * @param {string} [data.conductor.telefono] - Teléfono de contacto
+   * @param {string} [data.conductor.dni] - Documento de identidad
+   * @param {Object} [data.unidad] - Datos de la unidad anidados (puede ser null)
+   * @param {string} [data.unidad.id] - UUID de la unidad
+   * @param {string} [data.unidad.placa] - Placa del vehículo
+   * @param {string} [data.unidad.marca] - Marca del vehículo
+   * @param {string} [data.unidad.modelo] - Modelo del vehículo
+   */
+  constructor({
+    id,
+    codigo,
+    jornada_id,
+    tipo,
+    estado,
+    severidad,
+    detalle,
+    tipo_falla_mecanica,
+    latitud,
+    longitud,
+    direccion,
+    fecha_hora,
+    bloqueo_sos_activo,
+    conductor,
+    unidad,
+  }) {
+    this.id = id;
+    this.codigo = codigo;
+    this.jornada_id = jornada_id;
+    this.tipo = tipo;
+    this.estado = estado;
+    this.severidad = severidad;
+    this.detalle = detalle;
+    this.tipo_falla_mecanica = tipo_falla_mecanica;
+    this.latitud = latitud;
+    this.longitud = longitud;
+    this.direccion = direccion;
+    this.fecha_hora = fecha_hora;
+    this.bloqueo_sos_activo = bloqueo_sos_activo;
+    this.conductor = conductor;
+    this.unidad = unidad;
+  }
+
+  /**
+   * Serializa la instancia a un objeto plano JSON.
+   * Útil para respuestas HTTP sin exponer métodos internos.
+   *
+   * @returns {Object} Copia superficial de todos los atributos de la alerta
+   */
+  toJSON() {
+    return { ...this };
+  }
+
+  /**
+   * Mapea una fila cruda de PostgreSQL (con posibles prefijos de JOIN)
+   * a una instancia del modelo Alerta.
+   *
+   * @param {Object|null} row - Fila devuelta por node-postgres, o null
+   * @returns {Alerta|null} Instancia del modelo, o null si row es null
+   */
+  static fromDatabase(row) {
+    if (!row) return null;
+
+    return new Alerta({
+      id: row.id,
+      codigo: row.codigo ?? null,
+      jornada_id: row.jornada_id,
+      tipo: row.tipo,
+      estado: row.estado,
+      severidad: row.severidad,
+      detalle: row.detalle ?? null,
+      tipo_falla_mecanica: row.tipo_falla_mecanica ?? null,
+      latitud: row.latitud,
+      longitud: row.longitud,
+      direccion: row.direccion ?? null,
+      fecha_hora: row.fecha_hora,
+      bloqueo_sos_activo: row.bloqueo_sos_activo ?? false,
+      conductor: row.conductor_id
+        ? {
+            id: row.conductor_id,
+            nombre_completo: row.conductor_nombre_completo ?? null,
+            telefono: row.conductor_telefono ?? null,
+            dni: row.conductor_dni ?? null,
+          }
+        : null,
+      unidad: row.unidad_id
+        ? {
+            id: row.unidad_id,
+            placa: row.unidad_placa ?? null,
+            marca: row.unidad_marca ?? null,
+            modelo: row.unidad_modelo ?? null,
+          }
+        : null,
+    });
+  }
+
+  /**
+   * Mapea un arreglo de filas de PostgreSQL a un arreglo de instancias Alerta.
+   *
+   * @param {Object[]} rows - Filas devueltas por node-postgres
+   * @returns {Alerta[]} Lista de instancias del modelo
+   */
+  static fromDatabaseList(rows) {
+    if (!Array.isArray(rows)) return [];
+    return rows.map((row) => Alerta.fromDatabase(row));
+  }
+}

--- a/src/functions/alerta-services/alertaRepository.mjs
+++ b/src/functions/alerta-services/alertaRepository.mjs
@@ -1,0 +1,276 @@
+import { getClient } from "../../shared/config/database.mjs";
+
+/**
+ * Fragmento SQL base que selecciona los campos de alertas_jornada
+ * junto con los JOINs a jornadas, usuarios (conductor) y unidades.
+ * Se usa en findActivas para evitar repetir la estructura.
+ *
+ * @type {string}
+ */
+const BASE_SELECT_ACTIVAS = `
+  SELECT
+    a.id,
+    a.codigo,
+    a.jornada_id,
+    a.tipo,
+    a.estado,
+    a.severidad,
+    a.detalle,
+    a.tipo_falla_mecanica,
+    a.latitud,
+    a.longitud,
+    a.direccion,
+    a.fecha_hora,
+    a.bloqueo_sos_activo,
+    j.conductor_id,
+    u.nombres || ' ' || u.apellidos AS conductor_nombre_completo,
+    u.telefono AS conductor_telefono,
+    u.dni AS conductor_dni,
+    j.unidad_id,
+    un.placa AS unidad_placa,
+    un.marca AS unidad_marca,
+    un.modelo AS unidad_modelo
+  FROM alertas_jornada a
+  JOIN jornadas j ON j.id = a.jornada_id
+  JOIN usuarios u ON u.id = j.conductor_id
+  LEFT JOIN unidades un ON un.id = j.unidad_id
+`;
+
+/**
+ * Repositorio de acceso a datos para la entidad Alerta.
+ * Todas las operaciones obtienen un cliente de la pool de PostgreSQL
+ * y lo liberan en el bloque finally para evitar fugas de conexión.
+ *
+ * @class AlertaRepository
+ */
+export class AlertaRepository {
+  /**
+   * Obtiene los 3 contadores del panel de alertas en una sola query.
+   *
+   * - panico_activas: alertas tipo PANICO en estado ACTIVA
+   * - auxilio_pendientes: alertas tipo AUXILIO_MECANICO en estado ACTIVA o EN_PROCESO
+   * - total_resueltas: alertas en estado RESUELTA
+   * - tiene_panico_activo: booleano derivado (true si panico_activas > 0)
+   *
+   * @returns {Promise<Object>} Objeto con los 4 indicadores numéricos/booleanos
+   */
+  async getIndicadores() {
+    const client = await getClient();
+
+    try {
+      const result = await client.query(`
+        SELECT
+          COALESCE(COUNT(CASE WHEN tipo = 'PANICO' AND estado = 'ACTIVA' THEN 1 END), 0) AS panico_activas,
+          COALESCE(COUNT(CASE WHEN tipo = 'AUXILIO_MECANICO' AND estado IN ('ACTIVA', 'EN_PROCESO') THEN 1 END), 0) AS auxilio_pendientes,
+          COALESCE(COUNT(CASE WHEN estado = 'RESUELTA' THEN 1 END), 0) AS total_resueltas,
+          COALESCE(BOOL_OR(tipo = 'PANICO' AND estado = 'ACTIVA'), FALSE) AS tiene_panico_activo
+        FROM alertas_jornada;
+      `);
+
+      const row = result.rows[0];
+      return {
+        panico_activas: Number(row.panico_activas),
+        auxilio_pendientes: Number(row.auxilio_pendientes),
+        total_resueltas: Number(row.total_resueltas),
+        tiene_panico_activo: row.tiene_panico_activo,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Busca todas las alertas que NO están resueltas,
+   * aplicando filtros opcionales por tipo y estado.
+   * Ordena primero las ACTIVAS, luego EN_PROCESO, y dentro
+   * de cada grupo por fecha_hora descendente.
+   *
+   * @param {Object} [options={}] - Filtros opcionales
+   * @param {string} [options.tipo] - PANICO | AUXILIO_MECANICO | OBSERVACION
+   * @param {string} [options.estado] - ACTIVA | EN_PROCESO
+   * @returns {Promise<Object[]>} Filas con campos de alerta, conductor y unidad
+   */
+  async findActivas(options = {}) {
+    const client = await getClient();
+
+    try {
+      const conditions = ["a.estado IN ('ACTIVA', 'EN_PROCESO')"];
+      const params = [];
+
+      if (options.tipo) {
+        params.push(options.tipo);
+        conditions.push(`a.tipo = $${params.length}`);
+      }
+
+      if (options.estado) {
+        params.push(options.estado);
+        conditions.push(`a.estado = $${params.length}`);
+      }
+
+      const whereClause = `WHERE ${conditions.join(" AND ")}`;
+
+      const result = await client.query(
+        `
+          ${BASE_SELECT_ACTIVAS}
+          ${whereClause}
+          ORDER BY
+            CASE a.estado
+              WHEN 'ACTIVA' THEN 0
+              WHEN 'EN_PROCESO' THEN 1
+              ELSE 2
+            END,
+            a.fecha_hora DESC;
+        `,
+        params
+      );
+
+      return result.rows;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Busca una alerta por su ID primario.
+   *
+   * @param {string} id - UUID de la alerta
+   * @returns {Promise<Object|null>} Fila de la alerta o null si no existe
+   */
+  async findById(id) {
+    const client = await getClient();
+
+    try {
+      const result = await client.query(
+        `${BASE_SELECT_ACTIVAS} WHERE a.id = $1 LIMIT 1;`,
+        [id]
+      );
+      return result.rows[0] || null;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Marca una alerta como RESUELTA, registrando los datos de resolución.
+   * Siempre actualiza: estado = 'RESUELTA', atendida = TRUE, atendida_at = NOW().
+   * Opcionalmente persiste detalle_resolucion y servicio_tecnico_realizado
+   * cuando el objeto data los incluye.
+   *
+   * @param {string} id - UUID de la alerta a resolver
+   * @param {Object} [data={}] - Datos adicionales de resolución
+   * @param {string} [data.detalle_resolucion] - Descripción de cómo se resolvió
+   * @param {string} [data.servicio_tecnico_realizado] - Técnico o servicio involucrado
+   * @returns {Promise<Object|null>} Fila actualizada de la alerta, o null si no existía
+   */
+  async resolverAlerta(id, data = {}) {
+    const client = await getClient();
+
+    try {
+      const setClauses = [
+        "estado = 'RESUELTA'",
+        "atendida = TRUE",
+        "atendida_at = NOW()",
+      ];
+      const params = [id];
+
+      if (data.detalle_resolucion !== undefined) {
+        params.push(data.detalle_resolucion);
+        setClauses.push(`detalle_resolucion = $${params.length}`);
+      }
+
+      if (data.servicio_tecnico_realizado !== undefined) {
+        params.push(data.servicio_tecnico_realizado);
+        setClauses.push(`servicio_tecnico_realizado = $${params.length}`);
+      }
+
+      const result = await client.query(
+        `
+          UPDATE alertas_jornada
+          SET ${setClauses.join(", ")}
+          WHERE id = $1
+          RETURNING
+            id,
+            codigo,
+            jornada_id,
+            tipo,
+            estado,
+            severidad,
+            detalle,
+            tipo_falla_mecanica,
+            latitud,
+            longitud,
+            direccion,
+            fecha_hora,
+            atendida,
+            atendida_at,
+            detalle_resolucion,
+            servicio_tecnico_realizado,
+            telefono_contactado,
+            bloqueo_sos_activo,
+            created_at;
+        `,
+        params
+      );
+
+      return result.rows[0] || null;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Actualiza el estado operativo de una alerta de auxilio mecánico.
+   * Si el nuevo estado es 'RESUELTA', también marca atendida = TRUE y
+   * fija atendida_at = NOW().
+   *
+   * @param {string} id - UUID de la alerta
+   * @param {string} nuevoEstado - Estado objetivo (EN_PROCESO | RESUELTA)
+   * @returns {Promise<Object|null>} Fila actualizada de la alerta, o null si no existía
+   */
+  async actualizarEstado(id, nuevoEstado) {
+    const client = await getClient();
+
+    try {
+      const setClauses = ["estado = $2"];
+      const params = [id, nuevoEstado];
+
+      if (nuevoEstado === "RESUELTA") {
+        setClauses.push("atendida = TRUE");
+        setClauses.push("atendida_at = NOW()");
+      }
+
+      const result = await client.query(
+        `
+          UPDATE alertas_jornada
+          SET ${setClauses.join(", ")}
+          WHERE id = $1
+          RETURNING
+            id,
+            codigo,
+            jornada_id,
+            tipo,
+            estado,
+            severidad,
+            detalle,
+            tipo_falla_mecanica,
+            latitud,
+            longitud,
+            direccion,
+            fecha_hora,
+            atendida,
+            atendida_at,
+            detalle_resolucion,
+            servicio_tecnico_realizado,
+            telefono_contactado,
+            bloqueo_sos_activo,
+            created_at;
+        `,
+        params
+      );
+
+      return result.rows[0] || null;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/functions/alerta-services/alertaService.mjs
+++ b/src/functions/alerta-services/alertaService.mjs
@@ -1,0 +1,133 @@
+import { AlertaRepository } from "./alertaRepository.mjs";
+import { Alerta } from "./alertaModel.mjs";
+
+/**
+ * Estados válidos para la transición vía PATCH /alertas/{id}/estado.
+ * Solo se permite EN_PROCESO o RESUELTA en este endpoint.
+ *
+ * @type {Set<string>}
+ */
+const ESTADOS_VALIDOS_AUXILIO = new Set(["EN_PROCESO", "RESUELTA"]);
+
+/**
+ * Construye un error tipado para el dominio de alertas.
+ *
+ * @param {string} message - Mensaje descriptivo del error
+ * @param {number} [statusCode=400] - Código HTTP asociado
+ * @param {string} [code="ALERTA_ERROR"] - Código de error interno para el cliente
+ * @returns {Error} Error enriquecido con statusCode y code
+ */
+function createAlertaError(message, statusCode = 400, code = "ALERTA_ERROR") {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  error.code = code;
+  return error;
+}
+
+/**
+ * Servicio de dominio para la gestión de alertas y emergencias.
+ * Coordina las reglas de negocio, validaciones y el acceso al repositorio.
+ *
+ * @class AlertaService
+ */
+export class AlertaService {
+  constructor() {
+    this.repository = new AlertaRepository();
+  }
+
+  /**
+   * Obtiene los indicadores agregados del panel de alertas.
+   * Retorna contadores de pánico activo, auxilios pendientes,
+   * alertas resueltas y la bandera de pánico activo.
+   *
+   * @returns {Promise<Object>} Objeto plano con 4 campos:
+   *   panico_activas, auxilio_pendientes, total_resueltas, tiene_panico_activo
+   */
+  async getIndicadores() {
+    return this.repository.getIndicadores();
+  }
+
+  /**
+   * Obtiene todas las alertas no resueltas con sus relaciones de
+   * conductor y unidad, aplicando filtros opcionales.
+   *
+   * @param {Object} [filtros={}] - Criterios de filtrado
+   * @param {string} [filtros.tipo] - Tipo de alerta a filtrar
+   * @param {string} [filtros.estado] - Estado operativo a filtrar
+   * @returns {Promise<Alerta[]>} Lista de alertas mapeadas al modelo de dominio
+   */
+  async getAlertasActivas(filtros = {}) {
+    const rows = await this.repository.findActivas(filtros);
+    return Alerta.fromDatabaseList(rows);
+  }
+
+  /**
+   * Resuelve una alerta cambiando su estado a RESUELTA.
+   * Valida que la alerta exista y que no haya sido resuelta previamente.
+   *
+   * @param {string} id - UUID de la alerta
+   * @param {Object} [data={}] - Datos opcionales de resolución
+   * @param {string} [data.detalle_resolucion] - Detalle de cómo se resolvió
+   * @param {string} [data.servicio_tecnico_realizado] - Servicio técnico aplicado
+   * @returns {Promise<Alerta>} Alerta actualizada mapeada al modelo de dominio
+   * @throws {Error} 404 ALERTA_NOT_FOUND si la alerta no existe
+   * @throws {Error} 400 ALERTA_YA_RESUELTA si la alerta ya está resuelta
+   */
+  async resolverAlerta(id, data = {}) {
+    const alerta = await this.repository.findById(id);
+
+    if (!alerta) {
+      throw createAlertaError("Alerta no encontrada.", 404, "ALERTA_NOT_FOUND");
+    }
+
+    if (alerta.estado === "RESUELTA") {
+      throw createAlertaError(
+        "La alerta ya fue resuelta.",
+        400,
+        "ALERTA_YA_RESUELTA"
+      );
+    }
+
+    const updated = await this.repository.resolverAlerta(id, data);
+    return Alerta.fromDatabase(updated);
+  }
+
+  /**
+   * Actualiza el estado operativo de una alerta de auxilio mecánico.
+   * Solo aplica para alertas de tipo AUXILIO_MECANICO y estados
+   * permitidos: EN_PROCESO o RESUELTA.
+   *
+   * @param {string} id - UUID de la alerta
+   * @param {string} nuevoEstado - Estado objetivo (EN_PROCESO | RESUELTA)
+   * @returns {Promise<Alerta>} Alerta actualizada mapeada al modelo de dominio
+   * @throws {Error} 404 ALERTA_NOT_FOUND si la alerta no existe
+   * @throws {Error} 400 SOLO_AUXILIO_MECANICO si el tipo no es AUXILIO_MECANICO
+   * @throws {Error} 400 ESTADO_INVALIDO si el estado no es EN_PROCESO ni RESUELTA
+   */
+  async actualizarEstado(id, nuevoEstado) {
+    const alerta = await this.repository.findById(id);
+
+    if (!alerta) {
+      throw createAlertaError("Alerta no encontrada.", 404, "ALERTA_NOT_FOUND");
+    }
+
+    if (alerta.tipo !== "AUXILIO_MECANICO") {
+      throw createAlertaError(
+        "Solo aplica para auxilios mecánicos.",
+        400,
+        "SOLO_AUXILIO_MECANICO"
+      );
+    }
+
+    if (!ESTADOS_VALIDOS_AUXILIO.has(nuevoEstado)) {
+      throw createAlertaError(
+        "Estado inválido. Solo se permite EN_PROCESO o RESUELTA.",
+        400,
+        "ESTADO_INVALIDO"
+      );
+    }
+
+    const updated = await this.repository.actualizarEstado(id, nuevoEstado);
+    return Alerta.fromDatabase(updated);
+  }
+}


### PR DESCRIPTION
## Resumen
Implementa la **HU19: Panel de Alertas y Emergencias**, cerrando los issues #248 y #249.
## Issues relacionados
- Closes #248 — GET /alertas/indicadores y GET /alertas/activas
- Closes #249 — PATCH /alertas/{id}/resolver y PATCH /alertas/{id}/estado
## Cambios realizados
### Nuevos endpoints
| Método | Ruta | Descripción |
|---|---|---|
| `GET` | `/alertas/indicadores` | Retorna contadores de pánico activo, auxilios pendientes, resueltas y flag de banner |
| `GET` | `/alertas/activas` | Lista alertas no resueltas con JOINs a conductor y unidad. Filtros opcionales por `tipo` y `estado` |
| `PATCH` | `/alertas/{id}/resolver` | Marca alerta como `RESUELTA`. Body opcional: `detalle_resolucion`, `servicio_tecnico_realizado` |
| `PATCH` | `/alertas/{id}/estado` | Actualiza estado de auxilio mecánico (`EN_PROCESO` o `RESUELTA`). Valida que el tipo sea `AUXILIO_MECANICO` |
### Arquitectura (5 capas)
- `alertaModel.mjs` — Entidad `Alerta` con `fromDatabase()`, `fromDatabaseList()`, `toJSON()`
- `alertaRepository.mjs` — Acceso a datos con `getClient()` + liberación en `finally`
- `alertaService.mjs` — Lógica de negocio y errores tipados (`ALERTA_NOT_FOUND`, `ALERTA_YA_RESUELTA`, `SOLO_AUXILIO_MECANICO`, `ESTADO_INVALIDO`)
- `alertaController.mjs` — 4 controllers con validación de token (`getCurrentSession`)
- `alertaHandler.mjs` — Punto de entrada Lambda con tabla de rutas
### Tests unitarios
Creados en `__tests__/unit/alerta-services/`:
- `alertaController.test.mjs` — 9 casos
- `alertaService.test.mjs` — 6 casos
- `alertaRepository.test.mjs` — 6 casos
- `alertaHandler.test.mjs` — 5 casos
**Resultado:** `26/26 tests PASS`
## Reglas de negocio aplicadas
- Solo se puede resolver una alerta que no esté ya en estado `RESUELTA`
- El endpoint `PATCH /alertas/{id}/estado` solo aplica para alertas de tipo `AUXILIO_MECANICO`
- Estados permitidos: `EN_PROCESO`, `RESUELTA`
- Cuando el estado pasa a `RESUELTA`, se setea automáticamente `atendida = TRUE` y `atendida_at = NOW()`
- Todos los endpoints requieren autenticación Bearer
## Checklist
- [x] JSDoc completo en español en todas las funciones
- [x] Uso de `successResponse()` / `errorResponse()` con formato estándar
- [x] `getClient()` con liberación en bloque `finally`
- [x] Tests unitarios con `jest.unstable_mockModule`
- [x] No se modificó `package.json` ni archivos de otros servicios