### PR TITLE
fix: corrige listado de jornadas por join de alertas

### DIFF
--- a/src/functions/jornada-services/jornadaRepository.mjs
+++ b/src/functions/jornada-services/jornadaRepository.mjs
@@ -93,7 +93,7 @@ function buildFilters({
   }
   if (estado_alerta) {
     params.push(estado_alerta);
-    conditions.push(`a.tipo_alerta = $${params.length}`);
+    conditions.push(`a.tipo = $${params.length}`);
   }
   if (observaciones === "true") {
     conditions.push(`j.observaciones IS NOT NULL AND j.observaciones <> ''`);
@@ -439,7 +439,7 @@ export class JornadaRepository {
         JOIN usuarios u ON u.id = j.conductor_id
         JOIN unidades un ON un.id = j.unidad_id
         JOIN contratos c ON c.id = j.contrato_id
-        LEFT JOIN alertas a ON a.jornada_id = j.id
+        LEFT JOIN alertas_jornada a ON a.jornada_id = j.id
         ${whereClause}
         ORDER BY j.created_at DESC;
       `,
@@ -536,7 +536,7 @@ export class JornadaRepository {
         JOIN usuarios u ON u.id = j.conductor_id
         JOIN unidades un ON un.id = j.unidad_id
         JOIN contratos c ON c.id = j.contrato_id
-        LEFT JOIN alertas a ON a.jornada_id = j.id
+        LEFT JOIN alertas_jornada a ON a.jornada_id = j.id
 
         ${whereClause};
       `,
@@ -577,7 +577,7 @@ export class JornadaRepository {
         FROM jornadas j
         JOIN usuarios u ON u.id = j.conductor_id
         JOIN unidades un ON un.id = j.unidad_id
-        LEFT JOIN alertas a ON a.jornada_id = j.id
+        LEFT JOIN alertas_jornada a ON a.jornada_id = j.id
 
         WHERE j.id = $1
         LIMIT 1;


### PR DESCRIPTION
## Descripción

Se corrige el error 500 en `GET /jornadas` causado por una referencia incorrecta a la tabla de alertas.

## Problema

El endpoint hacía join con una tabla inexistente:

```sql
LEFT JOIN alertas a ON a.jornada_id = j.id
```

pero en el esquema real la tabla se llama:

```sql
alertas_jornada
```

Esto generaba el error:

```json
{
  "success": false,
  "message": "relation \"alertas\" does not exist",
  "data": {
    "code": "42P01"
  }
}
```

## Cambios

- Se cambió el join de `alertas` a `alertas_jornada`.
- Se corrigió el filtro de tipo de alerta de `a.tipo_alerta` a `a.tipo`.
- Se mantiene el alias `a`, por lo que no cambia la estructura de respuesta del endpoint.

## Validación

Se ejecutaron las pruebas unitarias específicas del módulo de jornadas:

```bash
npm run test -- __tests__/unit/jornada-services-test --runInBand
```

Resultado:

```text
47 passed
```