### PR TITLE
Fix: GET /alertas/activas ahora retorna todas las alertas cuando no se pasa filtro de estado.

### DIFF
--- a/__tests__/unit/alerta-services/alertaController.test.mjs
+++ b/__tests__/unit/alerta-services/alertaController.test.mjs
@@ -96,6 +96,39 @@ describe("AlertaController", () => {
     expect(body.data[0].tipo).toBe("PANICO");
   });
 
+  test("getAlertasActivasController sin filtros retorna todas las alertas incluyendo resueltas", async () => {
+    const mockGetAlertasActivas = jest.fn().mockResolvedValue([
+      {
+        id: "alert-1",
+        tipo: "PANICO",
+        estado: "ACTIVA",
+        severidad: "CRITICA",
+      },
+      {
+        id: "alert-2",
+        tipo: "AUXILIO_MECANICO",
+        estado: "RESUELTA",
+        severidad: "ALTA",
+        detalle_resolucion: "Cambio de bateria",
+      },
+    ]);
+
+    AlertaService.mockImplementation(() => ({
+      getAlertasActivas: mockGetAlertasActivas,
+    }));
+
+    const result = await getAlertasActivasController(withAuth());
+
+    expect(result.statusCode).toBe(200);
+    expect(mockGetAlertasActivas).toHaveBeenCalledWith(
+      expect.objectContaining({ tipo: undefined, estado: undefined })
+    );
+
+    const body = JSON.parse(result.body);
+    expect(body.data).toHaveLength(2);
+    expect(body.data[1].estado).toBe("RESUELTA");
+  });
+
   test("getAlertasActivasController filtra por tipo", async () => {
     const mockGetAlertasActivas = jest.fn().mockResolvedValue([]);
 

--- a/__tests__/unit/alerta-services/alertaRepository.test.mjs
+++ b/__tests__/unit/alerta-services/alertaRepository.test.mjs
@@ -60,13 +60,13 @@ describe("AlertaRepository", () => {
     expect(mockRelease).toHaveBeenCalled();
   });
 
-  test("findActivas sin filtros retorna todo", async () => {
+  test("findActivas sin filtros retorna todas las alertas", async () => {
     mockQuery.mockResolvedValue({ rows: [] });
 
     await repository.findActivas();
 
     expect(mockQuery).toHaveBeenCalledWith(
-      expect.stringContaining("a.estado IN ('ACTIVA', 'EN_PROCESO')"),
+      expect.not.stringContaining("a.estado IN ('ACTIVA', 'EN_PROCESO')"),
       []
     );
     expect(mockRelease).toHaveBeenCalled();

--- a/src/functions/alerta-services/alertaRepository.mjs
+++ b/src/functions/alerta-services/alertaRepository.mjs
@@ -80,21 +80,22 @@ export class AlertaRepository {
   }
 
   /**
-   * Busca todas las alertas que NO están resueltas,
-   * aplicando filtros opcionales por tipo y estado.
-   * Ordena primero las ACTIVAS, luego EN_PROCESO, y dentro
-   * de cada grupo por fecha_hora descendente.
+   * Busca todas las alertas aplicando filtros opcionales por tipo y estado.
+   * Si no se proporcionan filtros, retorna todas las alertas sin importar
+   * el estado operativo, incluyendo RESUELTA y FALSA_ALARMA.
+   * Ordena primero las ACTIVAS, luego EN_PROCESO, RESUELTA y FALSA_ALARMA,
+   * dentro de cada grupo por fecha_hora descendente.
    *
    * @param {Object} [options={}] - Filtros opcionales
    * @param {string} [options.tipo] - PANICO | AUXILIO_MECANICO | OBSERVACION
-   * @param {string} [options.estado] - ACTIVA | EN_PROCESO
+   * @param {string} [options.estado] - ACTIVA | EN_PROCESO | RESUELTA | FALSA_ALARMA
    * @returns {Promise<Object[]>} Filas con campos de alerta, conductor y unidad
    */
   async findActivas(options = {}) {
     const client = await getClient();
 
     try {
-      const conditions = ["a.estado IN ('ACTIVA', 'EN_PROCESO')"];
+      const conditions = [];
       const params = [];
 
       if (options.tipo) {
@@ -107,7 +108,7 @@ export class AlertaRepository {
         conditions.push(`a.estado = $${params.length}`);
       }
 
-      const whereClause = `WHERE ${conditions.join(" AND ")}`;
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
       const result = await client.query(
         `
@@ -117,7 +118,9 @@ export class AlertaRepository {
             CASE a.estado
               WHEN 'ACTIVA' THEN 0
               WHEN 'EN_PROCESO' THEN 1
-              ELSE 2
+              WHEN 'RESUELTA' THEN 2
+              WHEN 'FALSA_ALARMA' THEN 3
+              ELSE 4
             END,
             a.fecha_hora DESC;
         `,


### PR DESCRIPTION

Problema: El endpoint filtraba exclusivamente estado IN ('ACTIVA', 'EN_PROCESO'), por lo que las alertas RESUELTA no aparecían en el panel.
Solución: El filtro de estado se vuelve opcional (por query param). Sin filtro, retorna ACTIVA, EN_PROCESO, RESUELTA y FALSA_ALARMA.
Bug confirmado en testing: GET /alertas/activas?estado=RESUELTA retornaba [], ahora retornará el historial completo.