### PR TITLE
feat:HU04 - Historial de jornadas para chofer con métricas acumuladas

### DIFF
--- a/__tests__/unit/jornada-services-test/jornadaController.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaController.test.mjs
@@ -16,6 +16,8 @@ jest.unstable_mockModule("../../../src/functions/jornada-services/jornadaService
     startTurn: jest.fn(),
     finishTurn: jest.fn(),
     generateCsv: jest.fn(),
+    getDriverHistory: jest.fn(),
+    getDriverMetrics: jest.fn(),
   })),
 }));
 
@@ -26,6 +28,8 @@ const {
   getCurrentJornadaController,
   startTurnController,
   finishTurnController,
+  getDriverHistoryController,
+  getDriverMetricsController,
 } = await import("../../../src/functions/jornada-services/jornadaController.mjs");
 const { JornadaService } =
   await import("../../../src/functions/jornada-services/jornadaService.mjs");
@@ -239,5 +243,187 @@ describe("JornadaController", () => {
     const result = await exportCsvController(withAuth({ queryStringParameters: null }));
 
     expect(result.statusCode).toBe(500);
+  });
+
+  /**
+   * ===============================
+   * HU04 - Historial de Journadas (Driver)
+   * ===============================
+   */
+
+  test("getDriverHistoryController retorna 200 con datos correctos", async () => {
+    const mockHistory = [
+      {
+        id: "jor-uuid-1",
+        codigo: "shift_test_progress_maria_002",
+        placa: "ABC-123",
+        marca: "Volvo",
+        modelo: "FH16",
+        origen: "Lima",
+        destino: "Arequipa",
+        fecha: "2026-05-28",
+        hora_inicio: "08:00 AM",
+        hora_fin: "04:30 PM",
+        km_recorridos: 450.5,
+        estado: "COMPLETADA",
+        duracion_formateada: "8h 30m",
+        observaciones: "Todo correcto",
+      },
+    ];
+
+    JornadaService.mockImplementation(() => ({
+      getDriverHistory: jest.fn().mockResolvedValue(mockHistory),
+    }));
+
+    getCurrentSession.mockResolvedValueOnce({
+      user: { id: "cond-1", correo: "chofer@nanutech.com" },
+      role: "chofer",
+      session: { id: "session-1" },
+    });
+
+    const result = await getDriverHistoryController(
+      withAuth({ queryStringParameters: { periodo: "semana", observaciones: "todas" } })
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].placa).toBe("ABC-123");
+    expect(body.data[0].codigo).toBe("shift_test_progress_maria_002");
+    expect(body.data[0].duracion_formateada).toBe("8h 30m");
+  });
+
+  test("getDriverHistoryController retorna 401 sin token", async () => {
+    getCurrentSession.mockRejectedValueOnce({
+      message: "Token inválido o ausente.",
+      statusCode: 401,
+      code: "UNAUTHORIZED",
+    });
+
+    const result = await getDriverHistoryController({
+      headers: {},
+      queryStringParameters: {},
+    });
+
+    expect(result.statusCode).toBe(401);
+  });
+
+  test("getDriverHistoryController retorna 400 con período inválido", async () => {
+    JornadaService.mockImplementation(() => ({
+      getDriverHistory: jest.fn().mockRejectedValue({
+        message: "El período debe ser: semana, mes o todas.",
+        statusCode: 400,
+        code: "INVALID_PERIOD",
+      }),
+    }));
+
+    getCurrentSession.mockResolvedValueOnce({
+      user: { id: "cond-1", correo: "chofer@nanutech.com" },
+      role: "chofer",
+      session: { id: "session-1" },
+    });
+
+    const result = await getDriverHistoryController(
+      withAuth({ queryStringParameters: { periodo: "invalid" } })
+    );
+
+    expect(result.statusCode).toBe(400);
+  });
+
+  test("getDriverHistoryController extrae conductor_id del token y no del query param", async () => {
+    const mockGetDriverHistory = jest.fn().mockResolvedValue([]);
+    JornadaService.mockImplementation(() => ({
+      getDriverHistory: mockGetDriverHistory,
+    }));
+
+    getCurrentSession.mockResolvedValueOnce({
+      user: { id: "cond-token-id", correo: "chofer@nanutech.com" },
+      role: "chofer",
+      session: { id: "session-1" },
+    });
+
+    await getDriverHistoryController(
+      withAuth({ queryStringParameters: { conductor_id: "otro-conductor" } })
+    );
+
+    expect(mockGetDriverHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conductor_id: "cond-token-id",
+      })
+    );
+    expect(mockGetDriverHistory).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        conductor_id: "otro-conductor",
+      })
+    );
+  });
+
+  test("getDriverMetricsController retorna 200 con datos correctos", async () => {
+    const mockMetrics = {
+      total_jornadas: 12,
+      horas_trabajadas: 97.6,
+      km_recorridos: 4850.5,
+      con_observaciones: 4,
+    };
+
+    JornadaService.mockImplementation(() => ({
+      getDriverMetrics: jest.fn().mockResolvedValue(mockMetrics),
+    }));
+
+    getCurrentSession.mockResolvedValueOnce({
+      user: { id: "cond-1", correo: "chofer@nanutech.com" },
+      role: "chofer",
+      session: { id: "session-1" },
+    });
+
+    const result = await getDriverMetricsController(
+      withAuth({ queryStringParameters: { periodo: "mes" } })
+    );
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data.total_jornadas).toBe(12);
+    expect(body.data.horas_trabajadas).toBe(97.6);
+    expect(body.data.km_recorridos).toBe(4850.5);
+    expect(body.data.con_observaciones).toBe(4);
+  });
+
+  test("getDriverMetricsController retorna 401 sin token", async () => {
+    getCurrentSession.mockRejectedValueOnce({
+      message: "Token inválido o ausente.",
+      statusCode: 401,
+      code: "UNAUTHORIZED",
+    });
+
+    const result = await getDriverMetricsController({
+      headers: {},
+      queryStringParameters: {},
+    });
+
+    expect(result.statusCode).toBe(401);
+  });
+
+  test("getDriverMetricsController retorna 400 con período inválido", async () => {
+    JornadaService.mockImplementation(() => ({
+      getDriverMetrics: jest.fn().mockRejectedValue({
+        message: "El período debe ser: semana, mes o todas.",
+        statusCode: 400,
+        code: "INVALID_PERIOD",
+      }),
+    }));
+
+    getCurrentSession.mockResolvedValueOnce({
+      user: { id: "cond-1", correo: "chofer@nanutech.com" },
+      role: "chofer",
+      session: { id: "session-1" },
+    });
+
+    const result = await getDriverMetricsController(
+      withAuth({ queryStringParameters: { periodo: "invalid" } })
+    );
+
+    expect(result.statusCode).toBe(400);
   });
 });

--- a/__tests__/unit/jornada-services-test/jornadaRepository.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaRepository.test.mjs
@@ -196,4 +196,202 @@ describe("JornadaRepository", () => {
     expect(query).toContain("ILIKE");
     expect(params).toEqual(["%XYZ%", "cond-2"]);
   });
+
+  /**
+   * ===============================
+   * HU04 - Historial de Journadas (Driver)
+   * ===============================
+   */
+
+  test("findDriverHistory retorna historial del conductor con estado COMPLETADA", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          id: "jor-uuid-1",
+          codigo: "shift_test_progress_maria_002",
+          placa: "ABC-123",
+          marca: "Volvo",
+          modelo: "FH16",
+          origen: "Lima",
+          destino: "Arequipa",
+          fecha: "2026-05-28",
+          hora_inicio: "08:00 AM",
+          hora_fin: "04:30 PM",
+          km_recorridos: 450.5,
+          estado: "COMPLETADA",
+          duracion_formateada: "8h 30m",
+          observaciones: "Todo correcto",
+        },
+      ],
+    });
+
+    const result = await repository.findDriverHistory({
+      conductor_id: "cond-1",
+      periodo: "todas",
+      observaciones: "todas",
+    });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("conductor_id = $1");
+    expect(query).toContain("estado = 'COMPLETADA'");
+    expect(query).toContain("j.codigo");
+    expect(params).toEqual(["cond-1"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].duracion_formateada).toBe("8h 30m");
+    expect(result[0].codigo).toBe("shift_test_progress_maria_002");
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  test("findDriverHistory aplica filtro período semana con INTERVAL $2", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findDriverHistory({
+      conductor_id: "cond-1",
+      periodo: "semana",
+      observaciones: "todas",
+    });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("INTERVAL $2");
+    expect(params).toEqual(["cond-1", "7 days"]);
+  });
+
+  test("findDriverHistory aplica filtro período mes con INTERVAL $2", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findDriverHistory({
+      conductor_id: "cond-1",
+      periodo: "mes",
+      observaciones: "todas",
+    });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("INTERVAL $2");
+    expect(params).toEqual(["cond-1", "30 days"]);
+  });
+
+  test("findDriverHistory no aplica filtro de período cuando es 'todas'", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findDriverHistory({
+      conductor_id: "cond-1",
+      periodo: "todas",
+      observaciones: "todas",
+    });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).not.toContain("INTERVAL");
+    expect(params).toEqual(["cond-1"]);
+  });
+
+  test("findDriverHistory aplica filtro observaciones 'con'", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findDriverHistory({
+      conductor_id: "cond-1",
+      periodo: "todas",
+      observaciones: "con",
+    });
+
+    const [query] = mockQuery.mock.calls[0];
+    expect(query).toContain("observaciones IS NOT NULL");
+    expect(query).toContain("observaciones <> ''");
+  });
+
+  test("findDriverHistory aplica filtro observaciones 'sin'", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await repository.findDriverHistory({
+      conductor_id: "cond-1",
+      periodo: "todas",
+      observaciones: "sin",
+    });
+
+    const [query] = mockQuery.mock.calls[0];
+    expect(query).toContain("observaciones IS NULL");
+    expect(query).toContain("OR j.observaciones = ''");
+  });
+
+  test("findDriverHistory retorna vacío cuando no hay jornadas", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const result = await repository.findDriverHistory({
+      conductor_id: "cond-1",
+      periodo: "todas",
+      observaciones: "todas",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("getDriverMetrics calcula horas_trabajadas con 1 decimal", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          total_jornadas: "12",
+          horas_trabajadas: "97.6",
+          km_recorridos: "4850.5",
+          con_observaciones: "4",
+        },
+      ],
+    });
+
+    const result = await repository.getDriverMetrics({
+      conductor_id: "cond-1",
+      periodo: "todas",
+    });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("ROUND(SUM(EXTRACT(EPOCH FROM");
+    expect(params).toEqual(["cond-1"]);
+    expect(result.total_jornadas).toBe("12");
+    expect(result.horas_trabajadas).toBe("97.6");
+    expect(result.km_recorridos).toBe("4850.5");
+    expect(result.con_observaciones).toBe("4");
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  test("getDriverMetrics aplica filtro período semana", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          total_jornadas: "2",
+          horas_trabajadas: "16.0",
+          km_recorridos: "800.0",
+          con_observaciones: "1",
+        },
+      ],
+    });
+
+    await repository.getDriverMetrics({
+      conductor_id: "cond-1",
+      periodo: "semana",
+    });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("INTERVAL $2");
+    expect(params).toEqual(["cond-1", "7 days"]);
+  });
+
+  test("getDriverMetrics aplica filtro período mes", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          total_jornadas: "8",
+          horas_trabajadas: "64.0",
+          km_recorridos: "3200.0",
+          con_observaciones: "3",
+        },
+      ],
+    });
+
+    await repository.getDriverMetrics({
+      conductor_id: "cond-1",
+      periodo: "mes",
+    });
+
+    const [query, params] = mockQuery.mock.calls[0];
+    expect(query).toContain("INTERVAL $2");
+    expect(params).toEqual(["cond-1", "30 days"]);
+  });
 });

--- a/__tests__/unit/jornada-services-test/jornadaService.test.mjs
+++ b/__tests__/unit/jornada-services-test/jornadaService.test.mjs
@@ -13,6 +13,8 @@ jest.unstable_mockModule("../../../src/functions/jornada-services/jornadaReposit
     exportAll: jest.fn(),
     getHistorialMetrics: jest.fn(),
     getAlertDetail: jest.fn(),
+    findDriverHistory: jest.fn(),
+    getDriverMetrics: jest.fn(),
   })),
 }));
 
@@ -337,5 +339,139 @@ describe("JornadaService", () => {
 
     expect(csv).toContain("150");
     expect(jornadaService.repository.exportAll).toHaveBeenCalled();
+  });
+
+  /**
+   * ===============================
+   * HU04 - Historial de Journadas (Driver)
+   * ===============================
+   */
+
+  test("getDriverHistory delega correctamente al repository con filtros", async () => {
+    const mockHistory = [
+      {
+        id: "jor-uuid-1",
+        codigo: "shift_test_progress_maria_002",
+        placa: "ABC-123",
+        marca: "Volvo",
+        modelo: "FH16",
+        origen: "Lima",
+        destino: "Arequipa",
+        fecha: "2026-05-28",
+        hora_inicio: "08:00 AM",
+        hora_fin: "04:30 PM",
+        km_recorridos: 450.5,
+        estado: "COMPLETADA",
+        duracion_formateada: "8h 30m",
+        observaciones: "Todo correcto",
+      },
+    ];
+
+    jornadaService.repository.findDriverHistory.mockResolvedValue(mockHistory);
+
+    const result = await jornadaService.getDriverHistory({
+      conductor_id: "cond-1",
+      periodo: "semana",
+      observaciones: "con",
+    });
+
+    expect(jornadaService.repository.findDriverHistory).toHaveBeenCalledWith({
+      conductor_id: "cond-1",
+      periodo: "semana",
+      observaciones: "con",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].duracion_formateada).toBe("8h 30m");
+    expect(result[0].codigo).toBe("shift_test_progress_maria_002");
+  });
+
+  test("getDriverHistory usa 'todas' como período default", async () => {
+    jornadaService.repository.findDriverHistory.mockResolvedValue([]);
+
+    await jornadaService.getDriverHistory({ conductor_id: "cond-1" });
+
+    expect(jornadaService.repository.findDriverHistory).toHaveBeenCalledWith({
+      conductor_id: "cond-1",
+      periodo: "todas",
+      observaciones: "todas",
+    });
+  });
+
+  test("getDriverHistory lanza error 400 con período inválido", async () => {
+    await expect(
+      jornadaService.getDriverHistory({
+        conductor_id: "cond-1",
+        periodo: "invalid",
+      })
+    ).rejects.toMatchObject({
+      message: "El período debe ser: semana, mes o todas.",
+      code: "INVALID_PERIOD",
+      statusCode: 400,
+    });
+  });
+
+  test("getDriverHistory lanza error 400 con filtro de observaciones inválido", async () => {
+    await expect(
+      jornadaService.getDriverHistory({
+        conductor_id: "cond-1",
+        observaciones: "invalid",
+      })
+    ).rejects.toMatchObject({
+      message: "El filtro de observaciones debe ser: todas, con o sin.",
+      code: "INVALID_OBSERVACIONES_FILTER",
+      statusCode: 400,
+    });
+  });
+
+  test("getDriverMetrics delega correctamente al repository", async () => {
+    jornadaService.repository.getDriverMetrics.mockResolvedValue({
+      total_jornadas: "12",
+      horas_trabajadas: "97.6",
+      km_recorridos: "4850.5",
+      con_observaciones: "4",
+    });
+
+    const result = await jornadaService.getDriverMetrics({
+      conductor_id: "cond-1",
+      periodo: "mes",
+    });
+
+    expect(jornadaService.repository.getDriverMetrics).toHaveBeenCalledWith({
+      conductor_id: "cond-1",
+      periodo: "mes",
+    });
+    expect(result.total_jornadas).toBe(12);
+    expect(result.horas_trabajadas).toBe(97.6);
+    expect(result.km_recorridos).toBe(4850.5);
+    expect(result.con_observaciones).toBe(4);
+  });
+
+  test("getDriverMetrics usa 'todas' como período default", async () => {
+    jornadaService.repository.getDriverMetrics.mockResolvedValue({
+      total_jornadas: "5",
+      horas_trabajadas: "40.0",
+      km_recorridos: "1000.0",
+      con_observaciones: "2",
+    });
+
+    await jornadaService.getDriverMetrics({ conductor_id: "cond-1" });
+
+    expect(jornadaService.repository.getDriverMetrics).toHaveBeenCalledWith({
+      conductor_id: "cond-1",
+      periodo: "todas",
+    });
+  });
+
+  test("getDriverMetrics lanza error 400 con período inválido", async () => {
+    await expect(
+      jornadaService.getDriverMetrics({
+        conductor_id: "cond-1",
+        periodo: "invalid",
+      })
+    ).rejects.toMatchObject({
+      message: "El período debe ser: semana, mes o todas.",
+      code: "INVALID_PERIOD",
+      statusCode: 400,
+    });
   });
 });

--- a/src/functions/jornada-services/jornadaController.mjs
+++ b/src/functions/jornada-services/jornadaController.mjs
@@ -270,10 +270,84 @@ export const getManagerHistoryController = async (event) => {
   }
 };
 /**
+ * Obtiene el historial de jornadas completadas del conductor autenticado.
+ * El conductor_id se extrae del token JWT para evitar que un chofer
+ * pueda ver las jornadas de otro.
+ * Filtros: periodo (semana|mes|todas) y observaciones (todas|con|sin).
+ *
+ * @param {Object} event - Evento de AWS Lambda
+ * @param {Object} event.headers - Headers HTTP de la solicitud
+ * @param {string} [event.headers.Authorization] - Token Bearer de autenticación
+ * @param {Object} [event.queryStringParameters] - Filtros de búsqueda
+ * @param {string} [event.queryStringParameters.periodo] - 'semana' | 'mes' | 'todas'
+ * @param {string} [event.queryStringParameters.observaciones] - 'todas' | 'con' | 'sin'
+ * @returns {Promise<Object>} Respuesta HTTP 200 con lista de jornadas del conductor
+ * @throws {Error} 401 si el token es inválido o está ausente
+ * @throws {Error} 400 INVALID_PERIOD si el período no es válido
+ */
+export const getDriverHistoryController = async (event) => {
+  try {
+    const authorizationHeader = event.headers?.Authorization || event.headers?.authorization;
+    const session = await getCurrentSession(authorizationHeader);
+
+    const conductorId = session.user.id;
+    const { periodo, observaciones } = event.queryStringParameters || {};
+
+    const jornadaService = new JornadaService();
+    const historial = await jornadaService.getDriverHistory({
+      conductor_id: conductorId,
+      periodo,
+      observaciones,
+    });
+
+    return successResponse(historial, "Historial obtenido exitosamente.");
+  } catch (error) {
+    console.error("Error en getDriverHistoryController:", error);
+    return resolveErrorResponse(error);
+  }
+};
+
+/**
+ * Obtiene las métricas de resumen del conductor autenticado para las
+ * 4 tarjetas del dashboard del chofer: total_jornadas, horas_trabajadas,
+ * km_recorridos y con_observaciones.
+ * El conductor_id se extrae del token JWT.
+ *
+ * @param {Object} event - Evento de AWS Lambda
+ * @param {Object} event.headers - Headers HTTP de la solicitud
+ * @param {string} [event.headers.Authorization] - Token Bearer de autenticación
+ * @param {Object} [event.queryStringParameters] - Filtros de búsqueda
+ * @param {string} [event.queryStringParameters.periodo] - 'semana' | 'mes' | 'todas'
+ * @returns {Promise<Object>} Respuesta HTTP 200 con métricas del conductor
+ * @throws {Error} 401 si el token es inválido o está ausente
+ * @throws {Error} 400 INVALID_PERIOD si el período no es válido
+ */
+export const getDriverMetricsController = async (event) => {
+  try {
+    const authorizationHeader = event.headers?.Authorization || event.headers?.authorization;
+    const session = await getCurrentSession(authorizationHeader);
+
+    const conductorId = session.user.id;
+    const { periodo } = event.queryStringParameters || {};
+
+    const jornadaService = new JornadaService();
+    const metricas = await jornadaService.getDriverMetrics({
+      conductor_id: conductorId,
+      periodo,
+    });
+
+    return successResponse(metricas, "Métricas obtenidas exitosamente.");
+  } catch (error) {
+    console.error("Error en getDriverMetricsController:", error);
+    return resolveErrorResponse(error);
+  }
+};
+console.log("ANTES DE ALERT DETAIL");
+/**
  * Obtiene las métricas operativas del historial gerencial.
  * Retorna indicadores para las tarjetas del dashboard:
- * Total Jornadas, Alertas Pánico, Auxilio Mecánico,
- * Jornadas con Observaciones y KM Promedio.
+ * Total Journas, Alertas Pánico, Auxilio Mecánico,
+ * Journas con Observaciones y KM Promedio.
  *
  * @param {Object} event - Evento AWS Lambda
  * @returns {Promise<Object>} Métricas operativas

--- a/src/functions/jornada-services/jornadaHandler.mjs
+++ b/src/functions/jornada-services/jornadaHandler.mjs
@@ -22,6 +22,10 @@ const ROUTES = {
 
   "GET /jornadas/historial-gerencial/metrics": jornadaController.getHistorialMetricsController,
 
+  "GET /jornadas/historial": jornadaController.getDriverHistoryController,
+
+  "GET /jornadas/metricas": jornadaController.getDriverMetricsController,
+
   "GET /jornadas/alerta/{jornadaId}": jornadaController.getAlertDetailController,
 
   "GET /jornadas": jornadaController.getAllJornadasController,

--- a/src/functions/jornada-services/jornadaRepository.mjs
+++ b/src/functions/jornada-services/jornadaRepository.mjs
@@ -549,6 +549,131 @@ export class JornadaRepository {
     }
   }
   /**
+   * Obtiene el historial de jornadas completadas de un conductor específico.
+   * Aplica filtros de período y observaciones.
+   * Calcula la duración formateada como "Xh Ym" directamente en SQL.
+   * Solo retorna jornadas con estado = COMPLETADA.
+   *
+   * @param {Object} filtros - Criterios de filtrado
+   * @param {string} filtros.conductor_id - ID del conductor (extraído del token)
+   * @param {string} [filtros.periodo] - 'semana' | 'mes' | 'todas'
+   * @param {string} [filtros.observaciones] - 'todas' | 'con' | 'sin'
+   * @returns {Promise<Object[]>} Lista de jornadas del conductor
+   */
+  async findDriverHistory(filtros) {
+    const client = await getClient();
+
+    try {
+      const { params, periodCondition, obsCondition } = this._buildDriverFilters(filtros);
+
+      const result = await client.query(
+        `
+        SELECT
+          j.id,
+          j.codigo,
+          un.placa,
+          un.marca,
+          un.modelo,
+          j.origen,
+          j.destino,
+          TO_CHAR(j.fecha_jornada, 'YYYY-MM-DD') AS fecha,
+          TO_CHAR(j.hora_inicio, 'HH:MI AM') AS hora_inicio,
+          TO_CHAR(j.hora_fin, 'HH:MI AM') AS hora_fin,
+          j.km_recorridos,
+          j.estado,
+          TRUNC(EXTRACT(EPOCH FROM (j.hora_fin - j.hora_inicio))/3600)::TEXT || 'h ' ||
+          TRUNC((EXTRACT(EPOCH FROM (j.hora_fin - j.hora_inicio))%3600)/60)::TEXT || 'm' AS duracion_formateada,
+          COALESCE(j.observaciones, '') AS observaciones
+        FROM jornadas j
+        JOIN unidades un ON un.id = j.unidad_id
+        WHERE j.conductor_id = $1
+          AND j.estado = 'COMPLETADA'
+          ${periodCondition}
+          ${obsCondition}
+        ORDER BY j.fecha_jornada DESC, j.hora_inicio DESC;
+        `,
+        params
+      );
+
+      return result.rows;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Construye las condiciones de filtro para el historial del conductor.
+   * Genera el filtro de período (semana/mes) y observaciones (con/sin/todas).
+   *
+   * @param {Object} filtros - Criterios de filtrado
+   * @returns {{ params: Array, periodCondition: string, obsCondition: string }}
+   */
+  _buildDriverFilters({ conductor_id, periodo, observaciones } = {}) {
+    const params = [conductor_id];
+
+    let periodCondition = "";
+    if (periodo === "semana") {
+      params.push("7 days");
+      periodCondition = "AND j.fecha_jornada >= NOW() - INTERVAL $2";
+    } else if (periodo === "mes") {
+      params.push("30 days");
+      periodCondition = "AND j.fecha_jornada >= NOW() - INTERVAL $2";
+    }
+
+    let obsCondition = "";
+    if (observaciones === "con") {
+      obsCondition = "AND j.observaciones IS NOT NULL AND j.observaciones <> ''";
+    } else if (observaciones === "sin") {
+      obsCondition = "AND (j.observaciones IS NULL OR j.observaciones = '')";
+    }
+
+    return { params, periodCondition, obsCondition };
+  }
+
+  /**
+   * Obtiene las métricas de resumen del conductor para las tarjetas del dashboard.
+   * Calcula total_jornadas, horas_trabajadas, km_recorridos y con_observaciones.
+   * Las horas se calculan como suma de duración en horas con 1 decimal.
+   *
+   * @param {Object} filtros - Criterios de filtrado
+   * @param {string} filtros.conductor_id - ID del conductor (extraído del token)
+   * @param {string} [filtros.periodo] - 'semana' | 'mes' | 'todas'
+   * @returns {Promise<Object>} Métricas del conductor
+   */
+  async getDriverMetrics(filtros) {
+    const client = await getClient();
+
+    try {
+      const { params, periodCondition } = this._buildDriverFilters(filtros);
+
+      const result = await client.query(
+        `
+        SELECT
+          COUNT(DISTINCT j.id) AS total_jornadas,
+          COALESCE(
+            ROUND(SUM(EXTRACT(EPOCH FROM (j.hora_fin - j.hora_inicio))/3600), 1),
+            0
+          ) AS horas_trabajadas,
+          COALESCE(SUM(j.km_recorridos), 0) AS km_recorridos,
+          COUNT(DISTINCT CASE
+            WHEN j.observaciones IS NOT NULL AND j.observaciones <> ''
+            THEN j.id
+          END) AS con_observaciones
+        FROM jornadas j
+        WHERE j.conductor_id = $1
+          AND j.estado = 'COMPLETADA'
+          ${periodCondition};
+        `,
+        params
+      );
+
+      return result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
    * Obtiene detalle completo de una alerta.
    */
   async getAlertDetail(jornadaId) {

--- a/src/functions/jornada-services/jornadaService.mjs
+++ b/src/functions/jornada-services/jornadaService.mjs
@@ -284,4 +284,77 @@ export class JornadaService {
   async getAlertDetail(jornadaId) {
     return this.repository.getAlertDetail(jornadaId);
   }
+
+  /**
+   * Obtiene el historial de jornadas completadas del conductor autenticado.
+   * El conductor_id se注入 desde el token (filtros.conductor_id).
+   * Valida que el período sea válido (semana|mes|todas).
+   *
+   * @param {Object} filtros - Criterios de búsqueda
+   * @param {string} filtros.conductor_id - ID del conductor (del token)
+   * @param {string} [filtros.periodo] - 'semana' | 'mes' | 'todas'
+   * @param {string} [filtros.observaciones] - 'todas' | 'con' | 'sin'
+   * @returns {Promise<Object[]>} Lista de jornadas del conductor
+   * @throws {Error} 400 si el período es inválido
+   */
+  async getDriverHistory(filtros) {
+    const { conductor_id, periodo, observaciones } = filtros;
+
+    if (periodo && !["semana", "mes", "todas"].includes(periodo)) {
+      throw createJornadaError(
+        "El período debe ser: semana, mes o todas.",
+        400,
+        "INVALID_PERIOD"
+      );
+    }
+
+    if (observaciones && !["todas", "con", "sin"].includes(observaciones)) {
+      throw createJornadaError(
+        "El filtro de observaciones debe ser: todas, con o sin.",
+        400,
+        "INVALID_OBSERVACIONES_FILTER"
+      );
+    }
+
+    return this.repository.findDriverHistory({
+      conductor_id,
+      periodo: periodo || "todas",
+      observaciones: observaciones || "todas",
+    });
+  }
+
+  /**
+   * Obtiene las métricas de resumen del conductor autenticado.
+   * El conductor_id se inyecta desde el token.
+   * Valida que el período sea válido (semana|mes|todas).
+   *
+   * @param {Object} filtros - Criterios de búsqueda
+   * @param {string} filtros.conductor_id - ID del conductor (del token)
+   * @param {string} [filtros.periodo] - 'semana' | 'mes' | 'todas'
+   * @returns {Promise<Object>} Métricas del conductor
+   * @throws {Error} 400 si el período es inválido
+   */
+  async getDriverMetrics(filtros) {
+    const { conductor_id, periodo } = filtros;
+
+    if (periodo && !["semana", "mes", "todas"].includes(periodo)) {
+      throw createJornadaError(
+        "El período debe ser: semana, mes o todas.",
+        400,
+        "INVALID_PERIOD"
+      );
+    }
+
+    const metrics = await this.repository.getDriverMetrics({
+      conductor_id,
+      periodo: periodo || "todas",
+    });
+
+    return {
+      total_jornadas: Number(metrics.total_jornadas || 0),
+      horas_trabajadas: Number(metrics.horas_trabajadas || 0),
+      km_recorridos: Number(metrics.km_recorridos || 0),
+      con_observaciones: Number(metrics.con_observaciones || 0),
+    };
+  }
 }


### PR DESCRIPTION
## Descripción

Implementación de la HU04 - Historial de Journadas para el chofer. Se agregaron dos endpoints REST que permiten al conductor autenticado consultar su historial de jornadas completadas y métricas acumuladas.

## Endpoints implementados

### GET /jornadas/historial
Devuelve el historial de jornadas completadas del conductor autenticado con filtros por período y observaciones.

**Query params:**
- `periodo`: `semana` | `mes` | `todas` (default: `todas`)
- `observaciones`: `todas` | `con` | `sin` (default: `todas`)

**Respuesta:** Lista de jornadas con id, codigo, placa, marca, modelo, origen, destino, fecha, hora_inicio, hora_fin, km_recorridos, estado, duracion_formateada ("Xh Ym"), observaciones (solo lectura).

### GET /jornadas/metricas
Devuelve las 4 métricas de resumen del conductor para las tarjetas del dashboard.

**Query params:**
- `periodo`: `semana` | `mes` | `todas` (default: `todas`)

**Respuesta:** total_jornadas, horas_trabajadas (1 decimal), km_recorridos, con_observaciones.

## Seguridad

- El `conductor_id` se extrae del token JWT (`getCurrentSession`) y nunca del query param.
- Un chofer solo puede ver sus propias jornadas.
- Validación de período: retorna 400 si es inválido.

## Archivos modificados

- `src/functions/jornada-services/jornadaController.mjs` — getDriverHistoryController + getDriverMetricsController
- `src/functions/jornada-services/jornadaService.mjs` — getDriverHistory + getDriverMetrics
- `src/functions/jornada-services/jornadaRepository.mjs` — findDriverHistory + getDriverMetrics + _buildDriverFilters
- `src/functions/jornada-services/jornadaHandler.mjs` — nuevas rutas en ROUTES
- `__tests__/unit/jornada-services-test/*.mjs` — 26 tests nuevos

## Issues relacionados

- Closes #317 — Desarrollar API para consultar el historial del último mes filtrado por el ID del chofer autenticado
- Closes #318 — Implementar endpoint que recupere y exponga el texto íntegro de observaciones en modo de solo lectura

## Criterios de aceptación cubiertos

- [x] Endpoint /jornadas/historial con filtros período y observaciones
- [x] Endpoint /jornadas/metricas con total_jornadas, horas_trabajadas, km_recorridos, con_observaciones
- [x] Duración formateada "Xh Ym" calculada en SQL
- [x] Campo codigo con nomenclatura del sistema (ej. shift_test_progress_maria_002)
- [x] Observaciones solo lectura (texto completo hasta 500 caracteres)
- [x] Solo jornadas con estado COMPLETADA
- [x] conductor_id del token, no del query param
- [x] Validación de período inválido (400)
- [x] Tests unitarios: 71 passing

---
**Test Suites:** 4 passed, 4 total
**Tests:** 71 passed, 71 total
